### PR TITLE
fix: prefer existing VALKYR_AUTH before GrayMatter login

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,14 +288,16 @@ scripts/gm-entity Note POST '{"title":"Launch","content":"GrayMatter launch work
 
 GrayMatter uses:
 - `VALKYR_API_BASE`, default `https://api-0.valkyrlabs.com/v1`
-- macOS/iCloud Keychain lookup for `openclaw-valkyrai-admin-authToken`
+- macOS/iCloud Keychain lookup for `VALKYR_AUTH`
 - `VALKYR_AUTH_TOKEN` as the primary env override/debug path
+- `VALKYR_JWT_SESSION` as a compatible env fallback for downstream tooling
 
 Preferred auth flow:
-- prompt for username and password once
+- check Keychain for `VALKYR_AUTH` first
+- if present, reuse it automatically
+- otherwise prompt for username and password once
 - exchange for a `VALKYR_AUTH` token
-- store that token securely in Keychain
-- reuse automatically on future runs
+- store that token securely in Keychain for future runs
 
 Do not hardcode secrets into the repo or skill.
 Do not print tokens.
@@ -334,7 +336,7 @@ No env token is set and no matching macOS Keychain secret was found.
 Fix:
 - run `scripts/gm-login` and complete username/password sign-in, or
 - export `VALKYR_AUTH_TOKEN`, or
-- add Keychain secret `openclaw-valkyrai-admin-authToken`
+- ensure Keychain secret `VALKYR_AUTH` exists
 
 ### `jq: command not found`
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -216,14 +216,16 @@ scripts/gm-entity Note POST '{"title":"Launch note","content":"GrayMatter launch
 
 `graymatter_api.sh` uses:
 - `VALKYR_API_BASE`, defaulting to `https://api-0.valkyrlabs.com/v1`
-- macOS/iCloud Keychain lookup for `openclaw-valkyrai-admin-authToken`
+- macOS/iCloud Keychain lookup for `VALKYR_AUTH`
 - `VALKYR_AUTH_TOKEN` if already present as an override/debug path
+- `VALKYR_JWT_SESSION` as a compatible env fallback
 
 Preferred auth behavior is OpenClaw-first:
-- prompt for username/password
+- check Keychain for `VALKYR_AUTH` first
+- if present, reuse it automatically
+- otherwise prompt for username/password
 - exchange for a `VALKYR_AUTH` token
 - store it in Keychain
-- reuse automatically
 
 Do not hardcode secrets into the skill.
 Do not print tokens.

--- a/scripts/gm-install-check
+++ b/scripts/gm-install-check
@@ -24,14 +24,14 @@ have jq || fail 'jq is required'
 pass 'bash, curl, and jq are available'
 
 BASE="${VALKYR_API_BASE:-https://api-0.valkyrlabs.com/v1}"
-TOKEN="${VALKYR_AUTH_TOKEN:-}"
+TOKEN="${VALKYR_AUTH_TOKEN:-${VALKYR_JWT_SESSION:-}}"
 
 if [[ -z "$TOKEN" ]] && have security; then
-  TOKEN="$(security find-generic-password -a default -s openclaw-valkyrai-admin-authToken -w 2>/dev/null || true)"
+  TOKEN="$(security find-generic-password -a default -s VALKYR_AUTH -w 2>/dev/null || true)"
 fi
 
 if [[ -z "$TOKEN" ]]; then
-  fail 'No GrayMatter auth found. Set VALKYR_AUTH_TOKEN or add macOS Keychain secret openclaw-valkyrai-admin-authToken'
+  fail 'No GrayMatter auth found. Checked VALKYR_AUTH_TOKEN, VALKYR_JWT_SESSION, and macOS Keychain secret VALKYR_AUTH. Run scripts/gm-login if needed.'
 fi
 pass 'GrayMatter auth source detected'
 

--- a/scripts/gm-login
+++ b/scripts/gm-login
@@ -104,7 +104,7 @@ store_keychain() {
     echo "macOS security CLI not available for keychain mode" >&2
     exit 3
   fi
-  security add-generic-password -U -a default -s openclaw-valkyrai-admin-authToken -w "$AUTH_TOKEN" >/dev/null
+  security add-generic-password -U -a default -s VALKYR_AUTH -w "$AUTH_TOKEN" >/dev/null
   echo "Stored GrayMatter VALKYR_AUTH token securely in macOS/iCloud Keychain" >&2
 }
 

--- a/scripts/graymatter_api.sh
+++ b/scripts/graymatter_api.sh
@@ -11,14 +11,14 @@ if [[ -z "$METHOD" || -z "$PATH_PART" ]]; then
 fi
 
 BASE="${VALKYR_API_BASE:-https://api-0.valkyrlabs.com/v1}"
-TOKEN="${VALKYR_AUTH_TOKEN:-}"
+TOKEN="${VALKYR_AUTH_TOKEN:-${VALKYR_JWT_SESSION:-}}"
 
 if [[ -z "$TOKEN" ]] && command -v security >/dev/null 2>&1; then
-  TOKEN="$(security find-generic-password -a default -s openclaw-valkyrai-admin-authToken -w 2>/dev/null || true)"
+  TOKEN="$(security find-generic-password -a default -s VALKYR_AUTH -w 2>/dev/null || true)"
 fi
 
 if [[ -z "$TOKEN" ]]; then
-  echo "VALKYR_AUTH token is required" >&2
+  echo "VALKYR_AUTH token is required. Checked VALKYR_AUTH_TOKEN, VALKYR_JWT_SESSION, and keychain VALKYR_AUTH." >&2
   exit 2
 fi
 


### PR DESCRIPTION
## Summary
- use keychain service `VALKYR_AUTH` as the first-class auth source for GrayMatter
- let install-check and API transport accept `VALKYR_JWT_SESSION` as a compatible fallback
- update README and SKILL docs to reflect the real auth flow

## Validation
- bash -n scripts/gm-login scripts/gm-install-check scripts/gm-smoke scripts/graymatter_api.sh