### PR TITLE
feat: add GrayMatter status surface for auth, spool, and cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Rule:
 - `scripts/gm-graph` — inspect Swarm graph endpoints
 - `scripts/gm-openapi-sync` — fetch and cache the live OpenAPI spec locally
 - `scripts/gm-openapi-summary` — summarize live schema domains and endpoints
+- `scripts/gm-status` — quick health/status surface for auth source, fallback queue, and OpenAPI cache
 - `scripts/gm-entity` — generic helper for listing, reading, and writing arbitrary schema entities
 - `scripts/gm-register-agent` — register or refresh the OpenClaw server as an Agent in api-0
 - `scripts/package_graymatter.py` — deterministic validation and packaging
@@ -276,6 +277,7 @@ scripts/gm-graph GET
 ```bash
 scripts/gm-openapi-sync
 scripts/gm-openapi-summary
+scripts/gm-status
 ```
 
 ### Arbitrary schema entity access

--- a/scripts/gm-status
+++ b/scripts/gm-status
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FALLBACK_FILE="$ROOT_DIR/memory/graymatter-fallback.json"
+OPENAPI_CACHE="$ROOT_DIR/tmp/openapi.json"
+
+auth_state="missing"
+if [[ -n "${VALKYR_AUTH_TOKEN:-}" || -n "${VALKYR_AUTH:-}" || -n "${VALKYR_JWT_SESSION:-}" ]]; then
+  auth_state="env"
+elif command -v security >/dev/null 2>&1 && security find-generic-password -s "VALKYR_AUTH" -w >/dev/null 2>&1; then
+  auth_state="keychain"
+fi
+
+fallback_pending=0
+if [[ -f "$FALLBACK_FILE" ]]; then
+  fallback_pending="$(jq 'length' "$FALLBACK_FILE" 2>/dev/null || echo 0)"
+fi
+
+openapi_state="missing"
+if [[ -f "$OPENAPI_CACHE" ]]; then
+  openapi_state="cached"
+fi
+
+echo "graymatter_auth=$auth_state"
+echo "fallback_pending=$fallback_pending"
+echo "openapi_cache=$openapi_state"


### PR DESCRIPTION
Implements a small shippable slice of #7 by adding a first-class status surface for GrayMatter runtime health.\n\nWhat this adds:\n- scripts/gm-status for operator-visible health output\n- auth source detection (env, keychain, missing)\n- deferred-write spool depth from memory/graymatter-fallback.json\n- OpenAPI cache presence signal\n\nThis improves degraded-mode visibility and creates a concrete hook target for future plugin status wiring.