### PR TITLE
feat: add per-layer GrayMatter status surface

### DIFF
--- a/scripts/gm-status
+++ b/scripts/gm-status
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+FALLBACK_FILE="$ROOT_DIR/memory/graymatter-fallback.json"
+OPENAPI_CACHE="$ROOT_DIR/tmp/openapi.json"
+
+auth_state="missing"
+if [[ -n "${VALKYR_AUTH_TOKEN:-}" || -n "${VALKYR_AUTH:-}" || -n "${VALKYR_JWT_SESSION:-}" ]]; then
+  auth_state="env"
+elif command -v security >/dev/null 2>&1 && security find-generic-password -s "VALKYR_AUTH" -w >/dev/null 2>&1; then
+  auth_state="keychain"
+fi
+
+fallback_pending=0
+if [[ -f "$FALLBACK_FILE" ]]; then
+  fallback_pending="$(jq 'length' "$FALLBACK_FILE" 2>/dev/null || echo 0)"
+fi
+
+openapi_state="missing"
+if [[ -f "$OPENAPI_CACHE" ]]; then
+  openapi_state="cached"
+fi
+
+memory_layer="degraded"
+if [[ "$auth_state" != "missing" && "$fallback_pending" == "0" ]]; then
+  memory_layer="ready"
+fi
+
+graph_layer="unknown"
+strategic_layer="unknown"
+kpi_layer="unknown"
+
+if [[ "$openapi_state" == "cached" ]]; then
+  if jq -e '.paths["/SwarmOps/graph"] // .components.schemas.SwarmOps // empty' "$OPENAPI_CACHE" >/dev/null 2>&1; then
+    graph_layer="ready"
+  else
+    graph_layer="missing"
+  fi
+
+  if jq -e '.paths["/StrategicRecord"] // .components.schemas.StrategicRecord // empty' "$OPENAPI_CACHE" >/dev/null 2>&1; then
+    strategic_layer="ready"
+  else
+    strategic_layer="missing"
+  fi
+
+  if jq -e '.paths["/KPIRecord"] // .components.schemas.KPIRecord // empty' "$OPENAPI_CACHE" >/dev/null 2>&1; then
+    kpi_layer="ready"
+  else
+    kpi_layer="missing"
+  fi
+fi
+
+echo "graymatter_auth=$auth_state"
+echo "fallback_pending=$fallback_pending"
+echo "openapi_cache=$openapi_state"
+echo "memory_layer=$memory_layer"
+echo "graph_layer=$graph_layer"
+echo "strategic_layer=$strategic_layer"
+echo "kpi_layer=$kpi_layer"

--- a/tests/gm_status_test.sh
+++ b/tests/gm_status_test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/gm-status"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+mkdir -p "$TMP_DIR/memory" "$TMP_DIR/tmp"
+cat > "$TMP_DIR/memory/graymatter-fallback.json" <<'JSON'
+[]
+JSON
+cat > "$TMP_DIR/tmp/openapi.json" <<'JSON'
+{
+  "paths": {
+    "/SwarmOps/graph": {},
+    "/StrategicRecord": {},
+    "/KPIRecord": {}
+  }
+}
+JSON
+
+cp "$SCRIPT" "$TMP_DIR/gm-status"
+chmod +x "$TMP_DIR/gm-status"
+out="$(ROOT_DIR="$TMP_DIR" VALKYR_AUTH_TOKEN=test "$TMP_DIR/gm-status")"
+
+echo "$out" | grep -q '^graymatter_auth=env$'
+echo "$out" | grep -q '^memory_layer=ready$'
+echo "$out" | grep -q '^graph_layer=ready$'
+echo "$out" | grep -q '^strategic_layer=ready$'
+echo "$out" | grep -q '^kpi_layer=ready$'
+
+echo "gm_status_test: ok"


### PR DESCRIPTION
Closes #9

## What changed
- adds graymatter_auth=missing
fallback_pending=0
openapi_cache=missing
memory_layer=degraded
graph_layer=unknown
strategic_layer=unknown
kpi_layer=unknown to surface distinct layer readiness for memory, graph, strategic, and KPI domains
- reports auth, fallback queue, and openapi cache state in one command
- adds gm_status_test: ok to validate layer-ready output against a stub OpenAPI cache

## Why
Issue #9 asks for operator-visible status that clearly separates memory, graph, strategic, and KPI layers.