### PR TITLE
feat: add portable MCP memory tool contract v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Rule:
 - `scripts/gm-openapi-summary` — summarize live schema domains and endpoints
 - `scripts/gm-entity` — generic helper for listing, reading, and writing arbitrary schema entities
 - `scripts/gm-register-agent` — register or refresh the OpenClaw server as an Agent in api-0
+- `scripts/gm-mcp-contract` — emit the portable MCP memory-tool contract schema used by agent/IDE adapters
 - `scripts/package_graymatter.py` — deterministic validation and packaging
 - `docs/architecture.md` — architecture and operating model
 - `docs/prd-context-compaction-reset.md` — PRD for bounded chat compaction and reset flows
@@ -129,6 +130,7 @@ Rule:
 - `docs/graymatter-light.md` — local/offline notes
 - `examples/*` — example payloads and Light-mode starter assets
 - `references/*` — release and multi-agent guidance, including concurrency conventions
+- `references/mcp/memory-tool-contract.v1.json` — stable v1 portable tool contract for memory and graph operations
 - `clawhub.json` — publishing metadata
 
 ## Install and use immediately

--- a/references/mcp/memory-tool-contract.v1.json
+++ b/references/mcp/memory-tool-contract.v1.json
@@ -1,0 +1,19 @@
+{
+  "version": "v1",
+  "tools": [
+    {"name": "memory_query", "input": {"query": "string", "maxResults": "number?"}, "output": {"results": "array", "traceId": "string?"}},
+    {"name": "memory_get", "input": {"id": "string"}, "output": {"entry": "object|null", "traceId": "string?"}},
+    {"name": "memory_put", "input": {"type": "string", "content": "string", "source": "string?", "metadata": "object?"}, "output": {"id": "string", "status": "stored|deferred", "traceId": "string?"}},
+    {"name": "memory_put_batch", "input": {"items": "array", "maxBatch": "number<=100"}, "output": {"accepted": "number", "deferred": "number", "traceId": "string?"}},
+    {"name": "memory_link", "input": {"fromId": "string", "toId": "string", "relation": "string"}, "output": {"status": "linked", "traceId": "string?"}},
+    {"name": "memory_health", "input": {}, "output": {"apiReachable": "boolean", "fallbackQueueDepth": "number", "traceId": "string?"}},
+    {"name": "memory_replay_deferred", "input": {"limit": "number?"}, "output": {"attempted": "number", "replayed": "number", "remaining": "number", "traceId": "string?"}}
+  ],
+  "errors": {
+    "AUTH_REQUIRED": "No valid session",
+    "PERMISSION_DENIED": "RBAC denied",
+    "VALIDATION_ERROR": "Input failed schema validation",
+    "UPSTREAM_UNAVAILABLE": "api-0 unreachable",
+    "DEFERRED": "Write accepted into fallback spool"
+  }
+}

--- a/scripts/gm-mcp-contract
+++ b/scripts/gm-mcp-contract
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+CONTRACT_PATH="${ROOT_DIR}/references/mcp/memory-tool-contract.v1.json"
+
+if [[ ! -f "${CONTRACT_PATH}" ]]; then
+  printf 'contract file missing: %s\n' "${CONTRACT_PATH}" >&2
+  exit 1
+fi
+
+cat "${CONTRACT_PATH}"

--- a/tests/mcp_contract_test.sh
+++ b/tests/mcp_contract_test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONTRACT="${ROOT}/references/mcp/memory-tool-contract.v1.json"
+
+jq -e '.version == "v1"' "$CONTRACT" >/dev/null
+for t in memory_query memory_get memory_put memory_put_batch memory_link memory_health memory_replay_deferred; do
+  jq -e --arg t "$t" '.tools[] | select(.name==$t)' "$CONTRACT" >/dev/null
+done
+jq -e '.errors.AUTH_REQUIRED and .errors.UPSTREAM_UNAVAILABLE' "$CONTRACT" >/dev/null
+
+echo "mcp_contract_test: ok"


### PR DESCRIPTION
## Summary
Add a smallest-shippable slice for issue #6 by defining a stable portable MCP contract and shipping a deterministic accessor.

## Changes
- add  with v1 tool surface and error semantics
- add {
  "version": "v1",
  "tools": [
    {"name": "memory_query", "input": {"query": "string", "maxResults": "number?"}, "output": {"results": "array", "traceId": "string?"}},
    {"name": "memory_get", "input": {"id": "string"}, "output": {"entry": "object|null", "traceId": "string?"}},
    {"name": "memory_put", "input": {"type": "string", "content": "string", "source": "string?", "metadata": "object?"}, "output": {"id": "string", "status": "stored|deferred", "traceId": "string?"}},
    {"name": "memory_put_batch", "input": {"items": "array", "maxBatch": "number<=100"}, "output": {"accepted": "number", "deferred": "number", "traceId": "string?"}},
    {"name": "memory_link", "input": {"fromId": "string", "toId": "string", "relation": "string"}, "output": {"status": "linked", "traceId": "string?"}},
    {"name": "memory_health", "input": {}, "output": {"apiReachable": "boolean", "fallbackQueueDepth": "number", "traceId": "string?"}},
    {"name": "memory_replay_deferred", "input": {"limit": "number?"}, "output": {"attempted": "number", "replayed": "number", "remaining": "number", "traceId": "string?"}}
  ],
  "errors": {
    "AUTH_REQUIRED": "No valid session",
    "PERMISSION_DENIED": "RBAC denied",
    "VALIDATION_ERROR": "Input failed schema validation",
    "UPSTREAM_UNAVAILABLE": "api-0 unreachable",
    "DEFERRED": "Write accepted into fallback spool"
  }
} to emit the contract for adapters and IDE integrations
- add mcp_contract_test: ok to validate required tool names + critical error keys
- document new assets in README

## Validation
- mcp_contract_test: ok
- v1