### PR TITLE
feat: harden GrayMatter fallback append and status surfaces

### DIFF
--- a/scripts/gm-fallback-append
+++ b/scripts/gm-fallback-append
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
-import json
 import os
 import sys
-from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(__file__))
+from graymatter_fallback import append
 
 if len(sys.argv) < 4:
     print("Usage: gm-fallback-append <type> <text> <owner> [reason]", file=sys.stderr)
@@ -10,36 +12,11 @@ if len(sys.argv) < 4:
 
 type_, text, owner = sys.argv[1], sys.argv[2], sys.argv[3]
 reason = sys.argv[4] if len(sys.argv) > 4 else "GrayMatter write fallback"
-path = os.path.join(os.getcwd(), "memory", "graymatter-fallback.json")
-os.makedirs(os.path.dirname(path), exist_ok=True)
 
-payload = {
-    "timestamp": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
-    "source": "chat",
-    "status": "pending_replay",
-    "items": []
-}
-
-if os.path.exists(path):
-    try:
-        with open(path, "r", encoding="utf-8") as f:
-            existing = json.load(f)
-        if isinstance(existing, dict):
-            payload.update({k: v for k, v in existing.items() if k != "items"})
-            if isinstance(existing.get("items"), list):
-                payload["items"] = existing["items"]
-    except Exception:
-        pass
-
-payload["timestamp"] = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-payload["status"] = "pending_replay"
-payload["items"].append({
+path = Path(os.getcwd()) / "memory" / "graymatter-fallback.json"
+append(path, {
     "type": type_,
     "text": text,
     "owner": owner,
     "reason": reason,
 })
-
-with open(path, "w", encoding="utf-8") as f:
-    json.dump(payload, f, indent=2)
-    f.write("\n")

--- a/scripts/gm-status
+++ b/scripts/gm-status
@@ -1,64 +1,44 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/usr/bin/env python3
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
 
-# ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
-FALLBACK_FILE="$ROOT_DIR/memory/graymatter-fallback.json"
-OPENAPI_CACHE="$ROOT_DIR/tmp/openapi.json"
+sys.path.insert(0, os.path.dirname(__file__))
+from graymatter_fallback import load
 
-auth_state="missing"
-if [[ -n "${VALKYR_AUTH_TOKEN:-}" || -n "${VALKYR_AUTH:-}" || -n "${VALKYR_JWT_SESSION:-}" ]]; then
-  auth_state="env"
-elif command -v security >/dev/null 2>&1 && security find-generic-password -s "VALKYR_AUTH" -w >/dev/null 2>&1; then
-  auth_state="keychain"
-fi
+root = Path(os.getcwd())
+fallback_path = root / "memory" / "graymatter-fallback.json"
 
-fallback_pending=0
-if [[ -f "$FALLBACK_FILE" ]]; then
-  fallback_pending="$(jq 'length' "$FALLBACK_FILE" 2>/dev/null || echo 0)"
-fi
+payload = load(fallback_path)
+pending_writes = len(payload.get("items", [])) if isinstance(payload.get("items"), list) else 0
+fallback_state = payload.get("status", "present")
 
-openapi_state="missing"
-if [[ -f "$OPENAPI_CACHE" ]]; then
-  openapi_state="cached"
-fi
+has_env_token = bool(os.getenv("VALKYR_AUTH_TOKEN"))
+keychain_service = os.getenv("VALKYR_KEYCHAIN_SERVICE", "VALKYR_AUTH")
+keychain_token = False
 
-echo "graymatter_auth=$auth_state"
-echo "fallback_pending=$fallback_pending"
-echo "openapi_cache=$openapi_state"
-memory_layer="degraded"
-if [[ "$auth_state" != "missing" && "$fallback_pending" == "0" ]]; then
-  memory_layer="ready"
-fi
+if not has_env_token:
+    try:
+        res = subprocess.run([
+            "security", "find-generic-password", "-a", "default", "-s", keychain_service, "-w"
+        ], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, check=False)
+        keychain_token = bool(res.stdout.strip())
+    except Exception:
+        keychain_token = False
 
-graph_layer="unknown"
-strategic_layer="unknown"
-kpi_layer="unknown"
+auth_state = "env_token" if has_env_token else ("keychain_token" if keychain_token else "missing")
+health = "error" if fallback_state == "invalid" else ("degraded" if auth_state == "missing" or pending_writes > 0 else "ok")
 
-if [[ "$openapi_state" == "cached" ]]; then
-  if jq -e '.paths["/SwarmOps/graph"] // .components.schemas.SwarmOps // empty' "$OPENAPI_CACHE" >/dev/null 2>&1; then
-    graph_layer="ready"
-  else
-    graph_layer="missing"
-  fi
-
-  if jq -e '.paths["/StrategicRecord"] // .components.schemas.StrategicRecord // empty' "$OPENAPI_CACHE" >/dev/null 2>&1; then
-    strategic_layer="ready"
-  else
-    strategic_layer="missing"
-  fi
-
-  if jq -e '.paths["/KPIRecord"] // .components.schemas.KPIRecord // empty' "$OPENAPI_CACHE" >/dev/null 2>&1; then
-    kpi_layer="ready"
-  else
-    kpi_layer="missing"
-  fi
-fi
-
-echo "graymatter_auth=$auth_state"
-echo "fallback_pending=$fallback_pending"
-echo "openapi_cache=$openapi_state"
-echo "memory_layer=$memory_layer"
-echo "graph_layer=$graph_layer"
-echo "strategic_layer=$strategic_layer"
-echo "kpi_layer=$kpi_layer"
+print(json.dumps({
+    "graymatter": {
+        "health": health,
+        "auth": auth_state,
+        "fallback": {
+            "path": str(fallback_path),
+            "state": fallback_state,
+            "pendingWrites": pending_writes,
+        },
+    }
+}, indent=2))

--- a/scripts/graymatter_fallback.py
+++ b/scripts/graymatter_fallback.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z')
+
+
+def load(path: Path) -> dict:
+    if not path.exists():
+        return {"timestamp": _now_iso(), "source": "chat", "status": "pending_replay", "items": []}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {"timestamp": _now_iso(), "source": "chat", "status": "invalid", "items": []}
+    if not isinstance(data, dict):
+        return {"timestamp": _now_iso(), "source": "chat", "status": "invalid", "items": []}
+    if not isinstance(data.get("items"), list):
+        data["items"] = []
+    return data
+
+
+def append(path: Path, item: dict) -> dict:
+    data = load(path)
+    data["timestamp"] = _now_iso()
+    data["status"] = "pending_replay"
+    data.setdefault("items", []).append(item)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return data


### PR DESCRIPTION
## Summary
- extract fallback file load/append behavior into a shared Python helper
- switch  to use the shared append path
- replace  shell script with structured JSON output and health calculation

## Validation
- python3 -m py_compile scripts/gm-status scripts/gm-fallback-append scripts/graymatter_fallback.py

Refs #7