### PR TITLE
feat: add generic gm-client API wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Rule:
 - `scripts/gm-openapi-sync` — fetch and cache the live OpenAPI spec locally
 - `scripts/gm-openapi-summary` — summarize live schema domains and endpoints
 - `scripts/gm-status` — quick health/status surface for auth source, fallback queue, and OpenAPI cache
+- `scripts/gm-client` — generic REST wrapper for GET/POST/PUT/PATCH/DELETE against GrayMatter API paths
 - `scripts/gm-entity` — generic helper for listing, reading, and writing arbitrary schema entities
 - `scripts/gm-register-agent` — register or refresh the OpenClaw server as an Agent in api-0
 - `scripts/gm-mcp-contract` — emit the portable MCP memory-tool contract schema used by agent/IDE adapters

--- a/scripts/gm-client
+++ b/scripts/gm-client
@@ -14,12 +14,17 @@ Examples:
 EOF
 }
 
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+  usage
+  exit 0
+fi
+
 if [[ $# -lt 2 ]]; then
   usage
   exit 1
 fi
 
-method="${1^^}"
+method="$(printf '%s' "$1" | tr '[:lower:]' '[:upper:]')"
 path="$2"
 body="${3:-}"
 
@@ -28,6 +33,7 @@ case "$method" in
     "$API_SCRIPT" "$method" "$path" "$body"
     ;;
   *)
+    echo "error: unsupported method '$1'" >&2
     usage
     exit 1
     ;;

--- a/scripts/gm-client
+++ b/scripts/gm-client
@@ -6,7 +6,7 @@ API_SCRIPT="$ROOT_DIR/scripts/graymatter_api.sh"
 
 usage() {
   cat <<'EOF'
-Usage: gm-client <get|post|patch|delete> <path> [json-body]
+Usage: gm-client <get|post|put|patch|delete> <path> [json-body]
 
 Examples:
   gm-client get /memory-entries

--- a/scripts/gm-client
+++ b/scripts/gm-client
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+API_SCRIPT="$ROOT_DIR/scripts/graymatter_api.sh"
+
+usage() {
+  cat <<'EOF'
+Usage: gm-client <get|post|patch|delete> <path> [json-body]
+
+Examples:
+  gm-client get /memory-entries
+  gm-client post /memory-entries '{"title":"Decision","kind":"decision"}'
+EOF
+}
+
+if [[ $# -lt 2 ]]; then
+  usage
+  exit 1
+fi
+
+method="${1^^}"
+path="$2"
+body="${3:-}"
+
+case "$method" in
+  GET|POST|PATCH|DELETE|PUT)
+    "$API_SCRIPT" "$method" "$path" "$body"
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac

--- a/tests/gm_client_test.sh
+++ b/tests/gm_client_test.sh
@@ -9,4 +9,14 @@ fi
 
 grep -q "Usage: gm-client" /tmp/gm-client.out
 grep -q "get|post|put|patch|delete" /tmp/gm-client.out
+
+"$ROOT_DIR/scripts/gm-client" --help >/tmp/gm-client-help.out 2>&1
+grep -q "Usage: gm-client" /tmp/gm-client-help.out
+
+if "$ROOT_DIR/scripts/gm-client" foo /memory-entries >/tmp/gm-client-invalid.out 2>&1; then
+  echo "expected invalid method failure" >&2
+  exit 1
+fi
+grep -q "unsupported method 'foo'" /tmp/gm-client-invalid.out
+
 echo "gm_client_test: ok"

--- a/tests/gm_client_test.sh
+++ b/tests/gm_client_test.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if "$ROOT_DIR/scripts/gm-client" >/tmp/gm-client.out 2>&1; then
+  echo "expected usage failure" >&2
+  exit 1
+fi
+
+grep -q "Usage: gm-client" /tmp/gm-client.out
+echo "gm_client_test: ok"

--- a/tests/gm_client_test.sh
+++ b/tests/gm_client_test.sh
@@ -8,4 +8,5 @@ if "$ROOT_DIR/scripts/gm-client" >/tmp/gm-client.out 2>&1; then
 fi
 
 grep -q "Usage: gm-client" /tmp/gm-client.out
+grep -q "get|post|put|patch|delete" /tmp/gm-client.out
 echo "gm_client_test: ok"


### PR DESCRIPTION
## Summary\n- add  generic wrapper for GrayMatter API methods\n- support GET/POST/PUT/PATCH/DELETE path calls\n- add lightweight test for usage/argument validation\n\n## Testing\n- ./tests/gm_client_test.sh\n\nCloses #5