### PR TITLE
feat: portable MCP tool contract v1 slice

### DIFF
--- a/references/contracts/mcp/graymatter_mcp_contract_v1.json
+++ b/references/contracts/mcp/graymatter_mcp_contract_v1.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://valkyrlabs.com/graymatter/contracts/mcp/v1",
+  "title": "GrayMatter MCP Portable Tool Contract v1",
+  "type": "object",
+  "required": ["version", "tools"],
+  "additionalProperties": false,
+  "properties": {
+    "version": {"const": "v1"},
+    "tools": {
+      "type": "array",
+      "minItems": 7,
+      "items": {
+        "type": "object",
+        "required": ["name", "inputSchema", "outputSchema", "errors"],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": [
+              "memory_query",
+              "memory_get",
+              "memory_put",
+              "memory_put_batch",
+              "memory_link",
+              "memory_health",
+              "memory_replay_deferred"
+            ]
+          },
+          "inputSchema": {"type": "object"},
+          "outputSchema": {"type": "object"},
+          "errors": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["code", "retryable"],
+              "additionalProperties": false,
+              "properties": {
+                "code": {"type": "string", "minLength": 1},
+                "retryable": {"type": "boolean"}
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/references/contracts/mcp/graymatter_mcp_tools_v1.json
+++ b/references/contracts/mcp/graymatter_mcp_tools_v1.json
@@ -1,0 +1,12 @@
+{
+  "version": "v1",
+  "tools": [
+    {"name": "memory_query", "inputSchema": {"type": "object"}, "outputSchema": {"type": "object"}, "errors": [{"code": "invalid_request", "retryable": false}]},
+    {"name": "memory_get", "inputSchema": {"type": "object"}, "outputSchema": {"type": "object"}, "errors": [{"code": "not_found", "retryable": false}]},
+    {"name": "memory_put", "inputSchema": {"type": "object"}, "outputSchema": {"type": "object"}, "errors": [{"code": "unauthorized", "retryable": false}]},
+    {"name": "memory_put_batch", "inputSchema": {"type": "object"}, "outputSchema": {"type": "object"}, "errors": [{"code": "partial_failure", "retryable": true}]},
+    {"name": "memory_link", "inputSchema": {"type": "object"}, "outputSchema": {"type": "object"}, "errors": [{"code": "invalid_reference", "retryable": false}]},
+    {"name": "memory_health", "inputSchema": {"type": "object"}, "outputSchema": {"type": "object"}, "errors": [{"code": "service_unavailable", "retryable": true}]},
+    {"name": "memory_replay_deferred", "inputSchema": {"type": "object"}, "outputSchema": {"type": "object"}, "errors": [{"code": "replay_queue_empty", "retryable": false}]}
+  ]
+}

--- a/tests/mcp_portable_contract_test.sh
+++ b/tests/mcp_portable_contract_test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+contract="references/contracts/mcp/graymatter_mcp_tools_v1.json"
+
+jq -e '.version == "v1"' "$contract" >/dev/null
+jq -e '.tools | length >= 7' "$contract" >/dev/null
+jq -e '.tools | map(.name) | sort == ["memory_get","memory_health","memory_link","memory_put","memory_put_batch","memory_query","memory_replay_deferred"]' "$contract" >/dev/null
+jq -e '.tools[] | .errors | length >= 1' "$contract" >/dev/null
+jq -e '.tools[] | .errors[] | has("code") and has("retryable")' "$contract" >/dev/null
+
+echo "portable MCP contract surface checks passed"


### PR DESCRIPTION
## Summary\nAdds a minimal shippable slice for #6 by defining a portable MCP tool contract and a contract surface test.\n\n## Changes\n- Add  JSON schema for a stable MCP contract envelope\n- Add  canonical v1 tool list for memory/graph surface\n- Add portable MCP contract surface checks passed to enforce required tool names and error semantics shape\n\n## Validation\n- portable MCP contract surface checks passed\n\nCloses #6