### PR TITLE
feat: add --body-file support to gm-client

### DIFF
--- a/scripts/gm-client
+++ b/scripts/gm-client
@@ -6,18 +6,40 @@ API_SCRIPT="$ROOT_DIR/scripts/graymatter_api.sh"
 
 usage() {
   cat <<'EOF'
-Usage: gm-client <get|post|put|patch|delete> <path> [json-body]
+Usage: gm-client [--body-file <path>] <get|post|put|patch|delete> <path> [json-body]
 
 Examples:
   gm-client get /memory-entries
   gm-client post /memory-entries '{"title":"Decision","kind":"decision"}'
+  gm-client --body-file ./payload.json post /memory-entries
 EOF
 }
 
-if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
-  usage
-  exit 0
-fi
+body_file=""
+while [[ $# -gt 0 ]]; do
+  case "${1:-}" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --body-file)
+      body_file="${2:-}"
+      if [[ -z "$body_file" ]]; then
+        echo "error: --body-file requires a path" >&2
+        usage
+        exit 1
+      fi
+      shift 2
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 
 if [[ $# -lt 2 ]]; then
   usage
@@ -27,6 +49,18 @@ fi
 method="$(printf '%s' "$1" | tr '[:lower:]' '[:upper:]')"
 path="$2"
 body="${3:-}"
+
+if [[ -n "$body_file" ]]; then
+  if [[ -n "$body" ]]; then
+    echo "error: provide either [json-body] or --body-file, not both" >&2
+    exit 1
+  fi
+  if [[ ! -f "$body_file" ]]; then
+    echo "error: body file not found: $body_file" >&2
+    exit 1
+  fi
+  body="$(cat "$body_file")"
+fi
 
 case "$method" in
   GET|POST|PATCH|DELETE|PUT)

--- a/tests/gm_client_test.sh
+++ b/tests/gm_client_test.sh
@@ -8,6 +8,7 @@ if "$ROOT_DIR/scripts/gm-client" >/tmp/gm-client.out 2>&1; then
 fi
 
 grep -q "Usage: gm-client" /tmp/gm-client.out
+grep -q -- "--body-file" /tmp/gm-client.out
 grep -q "get|post|put|patch|delete" /tmp/gm-client.out
 
 "$ROOT_DIR/scripts/gm-client" --help >/tmp/gm-client-help.out 2>&1
@@ -18,5 +19,18 @@ if "$ROOT_DIR/scripts/gm-client" foo /memory-entries >/tmp/gm-client-invalid.out
   exit 1
 fi
 grep -q "unsupported method 'foo'" /tmp/gm-client-invalid.out
+
+if "$ROOT_DIR/scripts/gm-client" --body-file /no/such/file post /memory-entries >/tmp/gm-client-nofile.out 2>&1; then
+  echo "expected missing body-file failure" >&2
+  exit 1
+fi
+grep -q "body file not found" /tmp/gm-client-nofile.out
+
+echo '{"title":"From file"}' >/tmp/gm-client-body.json
+if "$ROOT_DIR/scripts/gm-client" --body-file /tmp/gm-client-body.json post /memory-entries '{"title":"Inline"}' >/tmp/gm-client-both.out 2>&1; then
+  echo "expected body conflict failure" >&2
+  exit 1
+fi
+grep -q "provide either \[json-body\] or --body-file" /tmp/gm-client-both.out
 
 echo "gm_client_test: ok"


### PR DESCRIPTION
## Summary
- add --body-file <path> support to scripts/gm-client so request payloads can be loaded from files
- enforce mutual exclusivity between inline body and --body-file
- extend tests/gm_client_test.sh coverage for help text and error paths

## Why
This is a small shippable slice toward issue #5 (shared client usability and stable call surfaces). It makes scripted/shared usage safer and less error-prone for larger payloads.

Closes #5
