### PR TITLE
feat: add fallback replay command for issue #7 slice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.tmp-light-bundle/
+.tmp-test-light-bundle/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Rule:
 - `scripts/gm-query` — query `MemoryEntry`
 - `scripts/gm-write` — write `MemoryEntry`, with tagged-write fallback behavior
 - `scripts/gm-fallback-append` — append failed writes to local replay queue at `memory/graymatter-fallback.json`
-- `scripts/gm-fallback-replay` — inspect pending fallback items and optionally mark them replayed with `--drain`
+- `scripts/gm-fallback-replay` — inspect pending fallback items, emit compact counts via `--summary`, and optionally mark them replayed with `--drain`
 - `scripts/gm-graph` — inspect Swarm graph endpoints
 - `scripts/gm-openapi-sync` — fetch and cache the live OpenAPI spec locally
 - `scripts/gm-openapi-summary` — summarize live schema domains and endpoints

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Rule:
 - `scripts/gm-query` — query `MemoryEntry`
 - `scripts/gm-write` — write `MemoryEntry`, with tagged-write fallback behavior
 - `scripts/gm-fallback-append` — append failed writes to local replay queue at `memory/graymatter-fallback.json`
+- `scripts/gm-fallback-replay` — inspect pending fallback items and optionally mark them replayed with `--drain`
 - `scripts/gm-graph` — inspect Swarm graph endpoints
 - `scripts/gm-openapi-sync` — fetch and cache the live OpenAPI spec locally
 - `scripts/gm-openapi-summary` — summarize live schema domains and endpoints

--- a/scripts/gm-fallback-replay
+++ b/scripts/gm-fallback-replay
@@ -12,6 +12,23 @@ data = load(path)
 items = data.get("items", [])
 json_mode = "--json" in sys.argv
 
+def parse_limit(argv):
+    if "--limit" not in argv:
+        return None
+    idx = argv.index("--limit")
+    if idx + 1 >= len(argv):
+        raise SystemExit("--limit requires a positive integer")
+    try:
+        value = int(argv[idx + 1])
+    except ValueError as exc:
+        raise SystemExit("--limit requires a positive integer") from exc
+    if value <= 0:
+        raise SystemExit("--limit requires a positive integer")
+    return value
+
+limit = parse_limit(sys.argv)
+view_items = items if limit is None else items[:limit]
+
 if not items:
     if json_mode:
         print(json.dumps({"status": "empty", "count": 0, "items": []}))
@@ -20,9 +37,9 @@ if not items:
     sys.exit(0)
 
 if json_mode:
-    print(json.dumps({"status": data.get("status", "pending_replay"), "count": len(items), "items": items}))
+    print(json.dumps({"status": data.get("status", "pending_replay"), "count": len(view_items), "total": len(items), "items": view_items}))
 else:
-    for idx, item in enumerate(items, start=1):
+    for idx, item in enumerate(view_items, start=1):
         print(f"[{idx}] type={item.get('type','')} owner={item.get('owner','')} reason={item.get('reason','')}")
         print(item.get("text", ""))
 

--- a/scripts/gm-fallback-replay
+++ b/scripts/gm-fallback-replay
@@ -12,6 +12,7 @@ data = load(path)
 items = data.get("items", [])
 json_mode = "--json" in sys.argv
 compact_mode = "--compact" in sys.argv
+summary_mode = "--summary" in sys.argv
 
 def compact_items(raw_items):
     compacted = []
@@ -70,11 +71,17 @@ if not items:
     sys.exit(0)
 
 if json_mode:
-    print(json.dumps({"status": data.get("status", "pending_replay"), "count": len(view_items), "total": len(items), "items": view_items}))
+    payload = {"status": data.get("status", "pending_replay"), "count": len(view_items), "total": len(items)}
+    if not summary_mode:
+        payload["items"] = view_items
+    print(json.dumps(payload))
 else:
-    for idx, item in enumerate(view_items, start=1):
-        print(f"[{idx}] type={item.get('type','')} owner={item.get('owner','')} reason={item.get('reason','')}")
-        print(item.get("text", ""))
+    if summary_mode:
+        print(f"status={data.get('status', 'pending_replay')} count={len(view_items)} total={len(items)}")
+    else:
+        for idx, item in enumerate(view_items, start=1):
+            print(f"[{idx}] type={item.get('type','')} owner={item.get('owner','')} reason={item.get('reason','')}")
+            print(item.get("text", ""))
 
 if "--drain" in sys.argv:
     if start >= len(items):

--- a/scripts/gm-fallback-replay
+++ b/scripts/gm-fallback-replay
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(__file__))
+from graymatter_fallback import load
+
+path = Path(os.getcwd()) / "memory" / "graymatter-fallback.json"
+data = load(path)
+items = data.get("items", [])
+
+if not items:
+    print("no pending fallback items")
+    sys.exit(0)
+
+for idx, item in enumerate(items, start=1):
+    print(f"[{idx}] type={item.get('type','')} owner={item.get('owner','')} reason={item.get('reason','')}")
+    print(item.get("text", ""))
+
+if "--drain" in sys.argv:
+    data["items"] = []
+    data["status"] = "replayed"
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    print(f"drained {len(items)} fallback items")

--- a/scripts/gm-fallback-replay
+++ b/scripts/gm-fallback-replay
@@ -50,7 +50,13 @@ else:
         print(item.get("text", ""))
 
 if "--drain" in sys.argv:
-    data["items"] = []
-    data["status"] = "replayed"
+    if start >= len(items):
+        drained = 0
+    else:
+        end = len(items) if limit is None else min(len(items), start + len(view_items))
+        del data["items"][start:end]
+        drained = end - start
+    if not data.get("items"):
+        data["status"] = "replayed"
     path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
-    print(f"drained {len(items)} fallback items")
+    print(f"drained {drained} fallback items")

--- a/scripts/gm-fallback-replay
+++ b/scripts/gm-fallback-replay
@@ -12,22 +12,28 @@ data = load(path)
 items = data.get("items", [])
 json_mode = "--json" in sys.argv
 
-def parse_limit(argv):
-    if "--limit" not in argv:
+def parse_positive_int_flag(argv, flag):
+    if flag not in argv:
         return None
-    idx = argv.index("--limit")
+    idx = argv.index(flag)
     if idx + 1 >= len(argv):
-        raise SystemExit("--limit requires a positive integer")
+        raise SystemExit(f"{flag} requires a positive integer")
     try:
         value = int(argv[idx + 1])
     except ValueError as exc:
-        raise SystemExit("--limit requires a positive integer") from exc
+        raise SystemExit(f"{flag} requires a positive integer") from exc
     if value <= 0:
-        raise SystemExit("--limit requires a positive integer")
+        raise SystemExit(f"{flag} requires a positive integer")
     return value
 
-limit = parse_limit(sys.argv)
-view_items = items if limit is None else items[:limit]
+limit = parse_positive_int_flag(sys.argv, "--limit")
+offset = parse_positive_int_flag(sys.argv, "--offset") or 1
+start = offset - 1
+if start >= len(items):
+    view_items = []
+else:
+    sliced = items[start:]
+    view_items = sliced if limit is None else sliced[:limit]
 
 if not items:
     if json_mode:

--- a/scripts/gm-fallback-replay
+++ b/scripts/gm-fallback-replay
@@ -10,14 +10,21 @@ from graymatter_fallback import load
 path = Path(os.getcwd()) / "memory" / "graymatter-fallback.json"
 data = load(path)
 items = data.get("items", [])
+json_mode = "--json" in sys.argv
 
 if not items:
-    print("no pending fallback items")
+    if json_mode:
+        print(json.dumps({"status": "empty", "count": 0, "items": []}))
+    else:
+        print("no pending fallback items")
     sys.exit(0)
 
-for idx, item in enumerate(items, start=1):
-    print(f"[{idx}] type={item.get('type','')} owner={item.get('owner','')} reason={item.get('reason','')}")
-    print(item.get("text", ""))
+if json_mode:
+    print(json.dumps({"status": data.get("status", "pending_replay"), "count": len(items), "items": items}))
+else:
+    for idx, item in enumerate(items, start=1):
+        print(f"[{idx}] type={item.get('type','')} owner={item.get('owner','')} reason={item.get('reason','')}")
+        print(item.get("text", ""))
 
 if "--drain" in sys.argv:
     data["items"] = []

--- a/scripts/gm-fallback-replay
+++ b/scripts/gm-fallback-replay
@@ -11,6 +11,33 @@ path = Path(os.getcwd()) / "memory" / "graymatter-fallback.json"
 data = load(path)
 items = data.get("items", [])
 json_mode = "--json" in sys.argv
+compact_mode = "--compact" in sys.argv
+
+def compact_items(raw_items):
+    compacted = []
+    for item in raw_items:
+        if not isinstance(item, dict):
+            continue
+        if not (item.get("type") and item.get("text") and item.get("owner")):
+            continue
+        compacted.append(item)
+    return compacted
+
+if compact_mode:
+    compacted_items = compact_items(items)
+    removed = len(items) - len(compacted_items)
+    data["items"] = compacted_items
+    if not compacted_items:
+        data["status"] = "replayed"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    items = compacted_items
+    if json_mode:
+        print(json.dumps({"status": data.get("status", "pending_replay"), "compacted": True, "removed": removed, "count": len(items)}))
+    else:
+        print(f"compacted fallback queue, removed {removed} invalid items")
+    if "--drain" not in sys.argv:
+        sys.exit(0)
 
 def parse_positive_int_flag(argv, flag):
     if flag not in argv:

--- a/tests/gm_fallback_replay_test.sh
+++ b/tests/gm_fallback_replay_test.sh
@@ -12,14 +12,21 @@ cat > "$TMP/memory/graymatter-fallback.json" <<JSON
   "source": "chat",
   "status": "pending_replay",
   "items": [
-    {"type":"note","text":"alpha","owner":"ops","reason":"retry"}
+    {"type":"note","text":"alpha","owner":"ops","reason":"retry"},
+    {"type":"task","text":"beta","owner":"ops","reason":"retry"}
   ]
 }
 JSON
 
+LIMIT_JSON="$(cd "$TMP" && $ROOT/scripts/gm-fallback-replay --json --limit 1 2>&1)"
+echo "$LIMIT_JSON" | grep -q '"count": 1'
+echo "$LIMIT_JSON" | grep -q '"total": 2'
+echo "$LIMIT_JSON" | grep -q '"alpha"'
+! echo "$LIMIT_JSON" | grep -q '"beta"'
+
 OUT="$(cd "$TMP" && $ROOT/scripts/gm-fallback-replay --drain 2>&1)"
 echo "$OUT" | grep -q "type=note"
-echo "$OUT" | grep -q "drained 1 fallback items"
+echo "$OUT" | grep -q "drained 2 fallback items"
 grep -q '"status": "replayed"' "$TMP/memory/graymatter-fallback.json"
 
 JSON_OUT="$(cd "$TMP" && $ROOT/scripts/gm-fallback-replay --json 2>&1)"

--- a/tests/gm_fallback_replay_test.sh
+++ b/tests/gm_fallback_replay_test.sh
@@ -13,14 +13,15 @@ cat > "$TMP/memory/graymatter-fallback.json" <<JSON
   "status": "pending_replay",
   "items": [
     {"type":"note","text":"alpha","owner":"ops","reason":"retry"},
-    {"type":"task","text":"beta","owner":"ops","reason":"retry"}
+    {"type":"task","text":"beta","owner":"ops","reason":"retry"},
+    {"text":"missing type","owner":"ops","reason":"retry"}
   ]
 }
 JSON
 
 LIMIT_JSON="$(cd "$TMP" && $ROOT/scripts/gm-fallback-replay --json --limit 1 2>&1)"
 echo "$LIMIT_JSON" | grep -q '"count": 1'
-echo "$LIMIT_JSON" | grep -q '"total": 2'
+echo "$LIMIT_JSON" | grep -q '"total": 3'
 echo "$LIMIT_JSON" | grep -q '"alpha"'
 ! echo "$LIMIT_JSON" | grep -q '"beta"'
 
@@ -28,6 +29,13 @@ OFFSET_JSON="$(cd "$TMP" && $ROOT/scripts/gm-fallback-replay --json --offset 2 -
 echo "$OFFSET_JSON" | grep -q '"count": 1'
 echo "$OFFSET_JSON" | grep -q '"beta"'
 ! echo "$OFFSET_JSON" | grep -q '"alpha"'
+
+COMPACT_JSON="$(cd "$TMP" && $ROOT/scripts/gm-fallback-replay --json --compact 2>&1)"
+echo "$COMPACT_JSON" | grep -q '"compacted": true'
+echo "$COMPACT_JSON" | grep -q '"removed": 1'
+
+grep -q '"type": "note"' "$TMP/memory/graymatter-fallback.json"
+! grep -q 'missing type' "$TMP/memory/graymatter-fallback.json"
 
 OUT="$(cd "$TMP" && $ROOT/scripts/gm-fallback-replay --offset 2 --limit 1 --drain 2>&1)"
 echo "$OUT" | grep -q "type=task"

--- a/tests/gm_fallback_replay_test.sh
+++ b/tests/gm_fallback_replay_test.sh
@@ -21,3 +21,7 @@ OUT="$(cd "$TMP" && $ROOT/scripts/gm-fallback-replay --drain 2>&1)"
 echo "$OUT" | grep -q "type=note"
 echo "$OUT" | grep -q "drained 1 fallback items"
 grep -q '"status": "replayed"' "$TMP/memory/graymatter-fallback.json"
+
+JSON_OUT="$(cd "$TMP" && $ROOT/scripts/gm-fallback-replay --json 2>&1)"
+echo "$JSON_OUT" | grep -q '"status": "empty"'
+echo "$JSON_OUT" | grep -q '"count": 0'

--- a/tests/gm_fallback_replay_test.sh
+++ b/tests/gm_fallback_replay_test.sh
@@ -29,9 +29,14 @@ echo "$OFFSET_JSON" | grep -q '"count": 1'
 echo "$OFFSET_JSON" | grep -q '"beta"'
 ! echo "$OFFSET_JSON" | grep -q '"alpha"'
 
-OUT="$(cd "$TMP" && $ROOT/scripts/gm-fallback-replay --drain 2>&1)"
-echo "$OUT" | grep -q "type=note"
-echo "$OUT" | grep -q "drained 2 fallback items"
+OUT="$(cd "$TMP" && $ROOT/scripts/gm-fallback-replay --offset 2 --limit 1 --drain 2>&1)"
+echo "$OUT" | grep -q "type=task"
+echo "$OUT" | grep -q "drained 1 fallback items"
+grep -q '"status": "pending_replay"' "$TMP/memory/graymatter-fallback.json"
+
+echo "$(cd "$TMP" && $ROOT/scripts/gm-fallback-replay --json 2>&1)" | grep -q '"total": 1'
+
+echo "$(cd "$TMP" && $ROOT/scripts/gm-fallback-replay --drain 2>&1)" | grep -q "drained 1 fallback items"
 grep -q '"status": "replayed"' "$TMP/memory/graymatter-fallback.json"
 
 JSON_OUT="$(cd "$TMP" && $ROOT/scripts/gm-fallback-replay --json 2>&1)"

--- a/tests/gm_fallback_replay_test.sh
+++ b/tests/gm_fallback_replay_test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/memory"
+cat > "$TMP/memory/graymatter-fallback.json" <<JSON
+{
+  "timestamp": "2026-01-01T00:00:00Z",
+  "source": "chat",
+  "status": "pending_replay",
+  "items": [
+    {"type":"note","text":"alpha","owner":"ops","reason":"retry"}
+  ]
+}
+JSON
+
+OUT="$(cd "$TMP" && $ROOT/scripts/gm-fallback-replay --drain 2>&1)"
+echo "$OUT" | grep -q "type=note"
+echo "$OUT" | grep -q "drained 1 fallback items"
+grep -q '"status": "replayed"' "$TMP/memory/graymatter-fallback.json"

--- a/tests/gm_fallback_replay_test.sh
+++ b/tests/gm_fallback_replay_test.sh
@@ -24,6 +24,11 @@ echo "$LIMIT_JSON" | grep -q '"total": 2'
 echo "$LIMIT_JSON" | grep -q '"alpha"'
 ! echo "$LIMIT_JSON" | grep -q '"beta"'
 
+OFFSET_JSON="$(cd "$TMP" && $ROOT/scripts/gm-fallback-replay --json --offset 2 --limit 1 2>&1)"
+echo "$OFFSET_JSON" | grep -q '"count": 1'
+echo "$OFFSET_JSON" | grep -q '"beta"'
+! echo "$OFFSET_JSON" | grep -q '"alpha"'
+
 OUT="$(cd "$TMP" && $ROOT/scripts/gm-fallback-replay --drain 2>&1)"
 echo "$OUT" | grep -q "type=note"
 echo "$OUT" | grep -q "drained 2 fallback items"


### PR DESCRIPTION
Implements a smallest shippable slice for #7 by adding a fallback replay utility:\n\n- adds scripts/gm-fallback-replay to list pending fallback items\n- supports --drain to mark queue as replayed after operator processing\n- adds tests/gm_fallback_replay_test.sh\n- documents the new helper in README\n\nThis keeps fallback spool handling visible and operational while full hook/replay automation is completed.