### PR TITLE
feat: expose portable MCP contract as default output

### DIFF
--- a/scripts/gm-mcp-contract
+++ b/scripts/gm-mcp-contract
@@ -5,7 +5,23 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 LEGACY_CONTRACT_PATH="${ROOT_DIR}/references/mcp/memory-tool-contract.v1.json"
 PORTABLE_CONTRACT_PATH="${ROOT_DIR}/references/contracts/mcp/graymatter_mcp_tools_v1.json"
-mode="${1:-portable}"
+mode="portable"
+if [[ $# -gt 0 ]]; then
+  case "$1" in
+    portable|legacy)
+      mode="$1"
+      shift
+      ;;
+    --mode=portable)
+      mode="portable"
+      shift
+      ;;
+    --mode=legacy)
+      mode="legacy"
+      shift
+      ;;
+  esac
+fi
 
 case "${mode}" in
   portable)
@@ -23,6 +39,10 @@ esac
 if [[ ! -f "${CONTRACT_PATH}" ]]; then
   printf 'contract file missing: %s\n' "${CONTRACT_PATH}" >&2
   exit 1
+fi
+
+if [[ "${1:-}" == "--validate" ]]; then
+  python3 -m json.tool "${CONTRACT_PATH}" >/dev/null
 fi
 
 cat "${CONTRACT_PATH}"

--- a/scripts/gm-mcp-contract
+++ b/scripts/gm-mcp-contract
@@ -3,7 +3,22 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
-CONTRACT_PATH="${ROOT_DIR}/references/mcp/memory-tool-contract.v1.json"
+LEGACY_CONTRACT_PATH="${ROOT_DIR}/references/mcp/memory-tool-contract.v1.json"
+PORTABLE_CONTRACT_PATH="${ROOT_DIR}/references/contracts/mcp/graymatter_mcp_tools_v1.json"
+mode="${1:-portable}"
+
+case "${mode}" in
+  portable)
+    CONTRACT_PATH="${PORTABLE_CONTRACT_PATH}"
+    ;;
+  legacy)
+    CONTRACT_PATH="${LEGACY_CONTRACT_PATH}"
+    ;;
+  *)
+    printf 'usage: %s [portable|legacy]\n' "$(basename "$0")" >&2
+    exit 2
+    ;;
+esac
 
 if [[ ! -f "${CONTRACT_PATH}" ]]; then
   printf 'contract file missing: %s\n' "${CONTRACT_PATH}" >&2

--- a/tests/mcp_contract_test.sh
+++ b/tests/mcp_contract_test.sh
@@ -2,12 +2,18 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-CONTRACT="${ROOT}/references/mcp/memory-tool-contract.v1.json"
+LEGACY_CONTRACT="${ROOT}/references/mcp/memory-tool-contract.v1.json"
+PORTABLE_CONTRACT="${ROOT}/references/contracts/mcp/graymatter_mcp_tools_v1.json"
 
-jq -e '.version == "v1"' "$CONTRACT" >/dev/null
+jq -e '.version == "v1"' "$LEGACY_CONTRACT" >/dev/null
+jq -e '.errors.AUTH_REQUIRED and .errors.UPSTREAM_UNAVAILABLE' "$LEGACY_CONTRACT" >/dev/null
+
+jq -e '.version == "v1"' "$PORTABLE_CONTRACT" >/dev/null
 for t in memory_query memory_get memory_put memory_put_batch memory_link memory_health memory_replay_deferred; do
-  jq -e --arg t "$t" '.tools[] | select(.name==$t)' "$CONTRACT" >/dev/null
+  jq -e --arg t "$t" '.tools[] | select(.name==$t)' "$PORTABLE_CONTRACT" >/dev/null
 done
-jq -e '.errors.AUTH_REQUIRED and .errors.UPSTREAM_UNAVAILABLE' "$CONTRACT" >/dev/null
+
+jq -e '.tools | map(.name) | sort == ["memory_get","memory_health","memory_link","memory_put","memory_put_batch","memory_query","memory_replay_deferred"]' < <("${ROOT}/scripts/gm-mcp-contract") >/dev/null
+jq -e '.errors.AUTH_REQUIRED and .errors.UPSTREAM_UNAVAILABLE' < <("${ROOT}/scripts/gm-mcp-contract" legacy) >/dev/null
 
 echo "mcp_contract_test: ok"

--- a/tests/mcp_contract_test.sh
+++ b/tests/mcp_contract_test.sh
@@ -14,6 +14,8 @@ for t in memory_query memory_get memory_put memory_put_batch memory_link memory_
 done
 
 jq -e '.tools | map(.name) | sort == ["memory_get","memory_health","memory_link","memory_put","memory_put_batch","memory_query","memory_replay_deferred"]' < <("${ROOT}/scripts/gm-mcp-contract") >/dev/null
+jq -e '.tools | length > 0' < <("${ROOT}/scripts/gm-mcp-contract" --mode=portable --validate) >/dev/null
 jq -e '.errors.AUTH_REQUIRED and .errors.UPSTREAM_UNAVAILABLE' < <("${ROOT}/scripts/gm-mcp-contract" legacy) >/dev/null
+jq -e '.errors.AUTH_REQUIRED and .errors.UPSTREAM_UNAVAILABLE' < <("${ROOT}/scripts/gm-mcp-contract" --mode=legacy --validate) >/dev/null
 
 echo "mcp_contract_test: ok"


### PR DESCRIPTION
## Summary
- make {
  "version": "v1",
  "tools": [
    {"name": "memory_query", "inputSchema": {"type": "object"}, "outputSchema": {"type": "object"}, "errors": [{"code": "invalid_request", "retryable": false}]},
    {"name": "memory_get", "inputSchema": {"type": "object"}, "outputSchema": {"type": "object"}, "errors": [{"code": "not_found", "retryable": false}]},
    {"name": "memory_put", "inputSchema": {"type": "object"}, "outputSchema": {"type": "object"}, "errors": [{"code": "unauthorized", "retryable": false}]},
    {"name": "memory_put_batch", "inputSchema": {"type": "object"}, "outputSchema": {"type": "object"}, "errors": [{"code": "partial_failure", "retryable": true}]},
    {"name": "memory_link", "inputSchema": {"type": "object"}, "outputSchema": {"type": "object"}, "errors": [{"code": "invalid_reference", "retryable": false}]},
    {"name": "memory_health", "inputSchema": {"type": "object"}, "outputSchema": {"type": "object"}, "errors": [{"code": "service_unavailable", "retryable": true}]},
    {"name": "memory_replay_deferred", "inputSchema": {"type": "object"}, "outputSchema": {"type": "object"}, "errors": [{"code": "replay_queue_empty", "retryable": false}]}
  ]
} default to the portable MCP tool contract
- keep legacy contract available via 
- extend MCP contract tests to validate both contract surfaces and script output

## Testing
- bash tests/mcp_contract_test.sh
- bash tests/mcp_portable_contract_test.sh

Closes #6