### PR TITLE
feat: add hook-event fallback spool capture (issue #7 slice)

### DIFF
--- a/scripts/gm-hook-event
+++ b/scripts/gm-hook-event
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(__file__))
+from graymatter_fallback import append
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Record an OpenClaw hook event into GrayMatter fallback spool"
+    )
+    parser.add_argument("event", help="Hook event name (for example: pre_tool or post_tool)")
+    parser.add_argument("text", help="Short event summary")
+    parser.add_argument("--owner", default=os.getenv("GRAYMATTER_OWNER", "valor"))
+    parser.add_argument("--session", default=os.getenv("OPENCLAW_SESSION_KEY", "unknown"))
+    parser.add_argument("--spool", default="memory/graymatter-fallback.json")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    spool = Path(os.getcwd()) / args.spool
+    payload = {
+        "type": "hookEvent",
+        "event": args.event,
+        "text": args.text,
+        "owner": args.owner,
+        "session": args.session,
+        "reason": "OpenClaw hook capture",
+    }
+    append(spool, payload)
+    print(json.dumps({"ok": True, "spool": str(spool), "event": args.event}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/gm_hook_event_test.sh
+++ b/tests/gm_hook_event_test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+rm -rf memory
+mkdir -p memory
+
+./scripts/gm-hook-event post_tool "tool completed" --owner test-owner --session s-123 >/tmp/gm-hook-event.out
+
+grep -q '"ok": true' /tmp/gm-hook-event.out
+
+grep -q '"event": "post_tool"' memory/graymatter-fallback.json
+grep -q '"session": "s-123"' memory/graymatter-fallback.json
+
+echo "gm_hook_event_test: ok"


### PR DESCRIPTION
## Summary
- add `scripts/gm-hook-event` to capture OpenClaw hook events into GrayMatter fallback spool
- include owner/session metadata for replay context
- add `tests/gm_hook_event_test.sh` for basic contract coverage

## Testing
- tests/gm_hook_event_test.sh

Refs #7