### PR TITLE
fix: improve gm-write long-payload failure clarity

### DIFF
--- a/scripts/gm-write
+++ b/scripts/gm-write
@@ -36,8 +36,13 @@ if [[ -n "$TAGS_RAW" ]] && printf '%s' "$RESPONSE" | grep -Eqi 'tags|tag|relatio
 fi
 
 TEXT_LEN=${#TEXT}
-if printf '%s' "$RESPONSE" | grep -Eqi 'data too long|value too long|string or binary data would be truncated|max.?length|payload too large|413'; then
-  echo "gm-write rejected payload length (chars=${TEXT_LEN}). Consider splitting into smaller chunks before retrying." >&2
+if printf '%s' "$RESPONSE" | grep -Eqi 'data too long|value too long|string or binary data would be truncated|max.?length|payload too large|413|entity too large|request entity too large'; then
+  echo "gm-write rejected payload length (chars=${TEXT_LEN})." >&2
+  echo "Hint: split text into smaller entries or summarize before writing." >&2
+fi
+
+if [[ $STATUS -ne 0 ]]; then
+  echo "gm-write failed (type=${TYPE}, sourceChannel=${SOURCE_CHANNEL}, chars=${TEXT_LEN}, exit=${STATUS})." >&2
 fi
 
 if [[ -x "${SCRIPT_DIR}/gm-fallback-append" ]]; then

--- a/tests/gm_write_test.sh
+++ b/tests/gm_write_test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cp "$ROOT_DIR/scripts/gm-write" "$TMP_DIR/gm-write"
+chmod +x "$TMP_DIR/gm-write"
+
+cat > "$TMP_DIR/graymatter_api.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "HTTP 413 Payload Too Large" >&2
+exit 1
+EOF
+chmod +x "$TMP_DIR/graymatter_api.sh"
+
+OUTPUT="$($TMP_DIR/gm-write todo "$(printf 'x%.0s' {1..1200})" test 2>&1 || true)"
+
+grep -q "gm-write rejected payload length" <<<"$OUTPUT"
+grep -q "gm-write failed (type=todo, sourceChannel=test" <<<"$OUTPUT"
+
+echo "gm_write_test: PASS"


### PR DESCRIPTION
## Summary\n- improve gm-write stderr diagnostics with explicit failure context (type/source/char count/exit code)\n- expand payload-too-large match patterns and add actionable hint\n- add regression test covering 413 long-payload failure output\n\n## Testing\n- tests/gm_write_test.sh\n\nCloses #2274