### PR TITLE
Package GrayMatter as Codex plugin

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,44 @@
+{
+  "name": "graymatter",
+  "version": "0.2.0",
+  "description": "Durable memory, shared graph state, and live ValkyrAI schema awareness for Codex and OpenClaw agents.",
+  "author": {
+    "name": "ValkyrLabs",
+    "email": "support@valkyrlabs.com",
+    "url": "https://valkyrlabs.com/"
+  },
+  "homepage": "https://github.com/ValkyrLabs/GrayMatter",
+  "repository": "https://github.com/ValkyrLabs/GrayMatter",
+  "license": "Proprietary",
+  "keywords": [
+    "graymatter",
+    "memory",
+    "durable-memory",
+    "agent-memory",
+    "schema-awareness",
+    "valkyrai",
+    "openclaw",
+    "codex"
+  ],
+  "skills": "./",
+  "interface": {
+    "displayName": "GrayMatter",
+    "shortDescription": "Durable memory and live schema context for agents",
+    "longDescription": "GrayMatter gives Codex and OpenClaw agents a durable memory layer, shared graph context, and authenticated awareness of the live ValkyrAI api-0 schema. Use it to persist decisions, query context, inspect business objects, and coordinate agent state through ValkyrAI.",
+    "developerName": "ValkyrLabs",
+    "category": "Productivity",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/ValkyrLabs/GrayMatter",
+    "termsOfServiceURL": "https://valkyrlabs.com/v1/docs/Legal/tos/",
+    "defaultPrompt": [
+      "Use GrayMatter to remember this decision",
+      "Query GrayMatter for relevant context",
+      "Inspect the ValkyrAI schema with GrayMatter"
+    ],
+    "brandColor": "#245B4A",
+    "screenshots": []
+  }
+}

--- a/docs/openai-app-directory-submission.md
+++ b/docs/openai-app-directory-submission.md
@@ -1,0 +1,37 @@
+# OpenAI App Directory Submission Notes
+
+## Current OpenAI paths
+
+- Legacy ChatGPT Plugins are no longer accepting new submissions.
+- ChatGPT App Directory submissions require an app built with the OpenAI Apps SDK, which extends MCP.
+- OpenAI Developers Showcase submissions are a separate promotional gallery and require a submitter identity, public project links, a cover image, and agreement to the Showcase Gallery Program terms.
+
+## GrayMatter readiness
+
+GrayMatter is now packaged as a local Codex plugin through `.codex-plugin/plugin.json`.
+That plugin packaging is useful for local Codex discovery, but it is not the same thing as a ChatGPT App Directory submission.
+
+To submit GrayMatter to the ChatGPT App Directory, the product still needs:
+
+- A deployed HTTPS Apps SDK/MCP endpoint for ChatGPT to connect to.
+- User authentication flow suitable for ChatGPT app review.
+- Public directory metadata, screenshots, and testing instructions.
+- A clear GrayMatter-specific privacy policy URL.
+- Country availability and review details entered from a verified OpenAI platform account.
+
+## Useful submission copy
+
+Title:
+GrayMatter
+
+Tagline:
+Durable memory and live schema context for business-native agents.
+
+Description:
+GrayMatter gives agents durable memory, shared graph context, and authenticated awareness of the live ValkyrAI api-0 schema. It helps Codex and OpenClaw workflows persist decisions, query reusable context, inspect business objects, and coordinate agent state inside an RBAC-scoped business data environment.
+
+Repository:
+https://github.com/ValkyrLabs/GrayMatter
+
+Setup:
+Clone the repository, install `jq`, run `scripts/gm-activate`, then use `scripts/gm-query`, `scripts/gm-write`, `scripts/gm-graph`, and `scripts/gm-entity` for memory and schema operations.


### PR DESCRIPTION
## Summary
- Add a Codex plugin manifest for GrayMatter so the existing skill can be installed as a plugin.
- Add OpenAI App Directory submission notes and reusable listing copy.
- Document that legacy ChatGPT plugin submissions are closed and that the current public path is an Apps SDK app submission.

## Verification
- `python3 -m json.tool .codex-plugin/plugin.json`
- `python3 -m json.tool ~/.agents/plugins/marketplace.json`
- `git status -sb` on `rc-6` is clean

## Notes
This PR contains commit `c1a7324 Package GrayMatter as Codex plugin` on `rc-6`.