### PR TITLE
fix(graymatter): surface stale/read-only auth in gm-status + gm-install-check

### DIFF
--- a/scripts/gm-install-check
+++ b/scripts/gm-install-check
@@ -74,6 +74,63 @@ if [[ -z "$TOKEN" ]]; then
 fi
 pass 'GrayMatter auth source detected'
 
+TOKEN_STATE="$(python3 - "$TOKEN" <<'PY'
+import base64
+import json
+import sys
+import time
+
+token = (sys.argv[1] if len(sys.argv) > 1 else "").strip()
+if not token:
+    print("missing")
+    raise SystemExit(0)
+
+parts = token.split(".")
+if len(parts) < 3:
+    print("ok")
+    raise SystemExit(0)
+
+try:
+    payload = parts[1] + ("=" * (-len(parts[1]) % 4))
+    claims = json.loads(base64.urlsafe_b64decode(payload.encode()).decode())
+except Exception:
+    print("ok")
+    raise SystemExit(0)
+
+exp = claims.get("exp")
+if isinstance(exp, (int, float)) and float(exp) <= time.time():
+    print("expired")
+    raise SystemExit(0)
+
+scopes = []
+raw_scope = claims.get("scope") or claims.get("scp")
+if isinstance(raw_scope, str):
+    scopes.extend(s.strip().lower() for s in raw_scope.replace(",", " ").split() if s.strip())
+elif isinstance(raw_scope, list):
+    scopes.extend(str(s).strip().lower() for s in raw_scope if str(s).strip())
+
+roles = claims.get("roles")
+if isinstance(roles, list):
+    scopes.extend(str(r).strip().lower() for r in roles if str(r).strip())
+
+read_only_markers = {"read", "readonly", "schema-read", "schema:read", "memory:read"}
+write_markers = {"write", "memory:write", "contentdata:write", "admin", "owner"}
+has_read_only = any(marker in scope for scope in scopes for marker in read_only_markers)
+has_write = any(marker in scope for scope in scopes for marker in write_markers)
+print("read_only" if has_read_only and not has_write else "ok")
+PY
+)"
+
+case "$TOKEN_STATE" in
+  expired)
+    fail "GrayMatter auth token is expired. Re-run gm-login to refresh your session."
+    ;;
+  read_only)
+    fail "GrayMatter auth token appears read-only. Use write-capable credentials before install validation."
+    ;;
+esac
+pass "GrayMatter auth token health: ${TOKEN_STATE}"
+
 if curl --silent --show-error --fail --max-time 10 "$BASE" >/dev/null 2>&1; then
   pass "API base reachable: $BASE"
 else

--- a/scripts/gm-status
+++ b/scripts/gm-status
@@ -3,6 +3,8 @@ import json
 import os
 import subprocess
 import sys
+import time
+import base64
 from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(__file__))
@@ -51,18 +53,63 @@ else:
 has_env_token = bool(os.getenv("VALKYR_AUTH_TOKEN"))
 keychain_service = os.getenv("VALKYR_KEYCHAIN_SERVICE", "VALKYR_AUTH")
 keychain_token = False
+resolved_token = (os.getenv("VALKYR_AUTH_TOKEN") or os.getenv("VALKYR_JWT_SESSION") or "").strip()
 
 if not has_env_token:
     try:
         res = subprocess.run([
             "security", "find-generic-password", "-a", "default", "-s", keychain_service, "-w"
         ], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, check=False)
-        keychain_token = bool(res.stdout.strip())
+        resolved_token = (res.stdout or "").strip()
+        keychain_token = bool(resolved_token)
     except Exception:
         keychain_token = False
 
+def _decode_jwt_payload(token: str):
+    if token.count(".") < 2:
+        return {}
+    try:
+        payload = token.split(".")[1]
+        payload += "=" * (-len(payload) % 4)
+        raw = base64.urlsafe_b64decode(payload.encode("utf-8"))
+        parsed = json.loads(raw.decode("utf-8"))
+        return parsed if isinstance(parsed, dict) else {}
+    except Exception:
+        return {}
+
+def _token_health(token: str):
+    if not token:
+        return "missing"
+
+    claims = _decode_jwt_payload(token)
+    exp = claims.get("exp")
+    if isinstance(exp, (int, float)) and float(exp) <= time.time():
+        return "expired"
+
+    scopes = []
+    raw_scope = claims.get("scope") or claims.get("scp")
+    if isinstance(raw_scope, str):
+        scopes.extend([s.strip().lower() for s in raw_scope.replace(",", " ").split() if s.strip()])
+    elif isinstance(raw_scope, list):
+        scopes.extend([str(s).strip().lower() for s in raw_scope if str(s).strip()])
+
+    roles = claims.get("roles")
+    if isinstance(roles, list):
+        scopes.extend([str(r).strip().lower() for r in roles if str(r).strip()])
+
+    read_only_markers = {"read", "readonly", "schema-read", "schema:read", "memory:read"}
+    write_markers = {"write", "memory:write", "contentdata:write", "admin", "owner"}
+    has_read_only = any(m in scope for scope in scopes for m in read_only_markers)
+    has_write = any(m in scope for scope in scopes for m in write_markers)
+    if has_read_only and not has_write:
+        return "read_only"
+
+    return "ok"
+
+token_state = _token_health(resolved_token)
+
 auth_state = "env_token" if has_env_token else ("keychain_token" if keychain_token else "missing")
-health = "error" if fallback_state == "invalid" else ("degraded" if auth_state == "missing" or pending_writes > 0 else "ok")
+health = "error" if fallback_state == "invalid" else ("degraded" if auth_state == "missing" or pending_writes > 0 or token_state in {"expired", "read_only"} else "ok")
 
 if os.getenv("GM_STATUS_FORMAT", "kv") == "json":
     print(json.dumps({
@@ -78,7 +125,7 @@ if os.getenv("GM_STATUS_FORMAT", "kv") == "json":
     }, indent=2))
 else:
     auth_kv = "env" if has_env_token else ("keychain" if keychain_token else "missing")
-    memory_layer = "ready" if fallback_state != "invalid" else "degraded"
+    memory_layer = "ready" if fallback_state != "invalid" and token_state == "ok" else "degraded"
     graph_layer = strategic_layer = kpi_layer = "unknown"
     try:
         with open(openapi_path, "r", encoding="utf-8") as fh:
@@ -91,6 +138,7 @@ else:
         graph_layer = strategic_layer = kpi_layer = "missing"
 
     print(f"graymatter_auth={auth_kv}")
+    print(f"graymatter_token_state={token_state}")
     print(f"memory_layer={memory_layer}")
     print(f"graph_layer={graph_layer}")
     print(f"strategic_layer={strategic_layer}")


### PR DESCRIPTION
## Summary\n- decode JWT token claims in  to detect expired/read-only auth\n- mark  when token is stale or read-only\n- add  key for fast diagnostics\n- fail  early when token is expired/read-only\n\n## Why\nValkyrLabs/ValkyrAI#2570 reports stale keychain tokens being shown as ready, which blocks ContentData + file-upload validation while hiding auth drift.\n\n## Validation\n- graymatter_auth=missing
graymatter_token_state=missing
memory_layer=degraded
graph_layer=missing
strategic_layer=missing
kpi_layer=missing\n- 