### PR TITLE
feat: add awesome-codex-plugins listing kit (#35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,21 @@ That creates `dist/graymatter-local-server-latest.tar.gz`. The archive contains:
 
 The embedded dashboard includes Valkyr Labs branding, hides the local login panel after successful login, exposes `Promote / Synchronize` for the valkyrlabs.com mothership bridge, and reports the local `graymatter-swarm-v0.1` light-node status.
 
+## awesome-codex-plugins listing kit
+
+GrayMatter ships a ready-to-submit listing packet for `awesome-codex-plugins`.
+
+- Listing markdown block: `docs/awesome-codex-plugins.md`
+- Source metadata: `.codex-plugin/plugin.json`
+
+Quick copy flow:
+
+```bash
+cat docs/awesome-codex-plugins.md
+```
+
+Then open a PR against `hashgraph-online/awesome-codex-plugins` and paste the generated block into `README.md` using that repository's contribution format.
+
 ## Launch position
 
 The launch target is simple:

--- a/docs/awesome-codex-plugins.md
+++ b/docs/awesome-codex-plugins.md
@@ -1,0 +1,1 @@
+- [GrayMatter](https://github.com/ValkyrLabs/GrayMatter) — Durable memory, shared graph state, and live ValkyrAI schema awareness for Codex and OpenClaw agents.

--- a/tests/awesome_codex_listing_test.sh
+++ b/tests/awesome_codex_listing_test.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PLUGIN_JSON="$ROOT_DIR/.codex-plugin/plugin.json"
+LISTING_DOC="$ROOT_DIR/docs/awesome-codex-plugins.md"
+
+[[ -f "$PLUGIN_JSON" ]]
+[[ -f "$LISTING_DOC" ]]
+
+name="$(jq -r '.name' "$PLUGIN_JSON")"
+repo="$(jq -r '.repository' "$PLUGIN_JSON")"
+description="$(jq -r '.description' "$PLUGIN_JSON")"
+
+[[ "$name" == "graymatter" ]]
+[[ "$repo" == "https://github.com/ValkyrLabs/GrayMatter" ]]
+
+expected_line="- [GrayMatter](https://github.com/ValkyrLabs/GrayMatter) — $description"
+grep -Fx -- "$expected_line" "$LISTING_DOC" >/dev/null
+
+echo "awesome_codex_listing_test: ok"


### PR DESCRIPTION
## Summary
- add a ready-to-paste awesome-codex-plugins listing line in docs/awesome-codex-plugins.md
- document the listing kit location in README
- add a regression test that validates listing text against .codex-plugin/plugin.json metadata

## Testing
- tests/awesome_codex_listing_test.sh