### PR TITLE
fix(gm-status): mark stale/unknown auth as degraded

### DIFF
--- a/scripts/gm-status
+++ b/scripts/gm-status
@@ -54,6 +54,7 @@ else:
 
 has_env_token = bool(os.getenv("VALKYR_AUTH_TOKEN"))
 keychain_service = os.getenv("VALKYR_KEYCHAIN_SERVICE", "VALKYR_AUTH")
+username_service = os.getenv("VALKYR_USERNAME_KEYCHAIN_SERVICE", f"{keychain_service}_USERNAME")
 api_base = os.getenv("VALKYR_API_BASE", "https://api-0.valkyrlabs.com/v1").rstrip("/")
 keychain_token = False
 token_value = os.getenv("VALKYR_AUTH_TOKEN", "").strip()
@@ -61,13 +62,26 @@ resolved_token = (os.getenv("VALKYR_AUTH_TOKEN") or os.getenv("VALKYR_JWT_SESSIO
 
 if not has_env_token:
     try:
+        username_res = subprocess.run([
+            "security", "find-generic-password", "-a", "default", "-s", username_service, "-w"
+        ], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, check=False)
+        keychain_username = (username_res.stdout or "").strip()
+
+        if keychain_username:
+            keyed_res = subprocess.run([
+                "security", "find-generic-password", "-a", keychain_username, "-s", keychain_service, "-w"
+            ], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, check=False)
+            if keyed_res.returncode == 0 and (keyed_res.stdout or "").strip():
+                token_value = keyed_res.stdout.strip()
+                resolved_token = token_value
+
         res = subprocess.run([
             "security", "find-generic-password", "-a", "default", "-s", keychain_service, "-w"
         ], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, check=False)
-        token_value = res.stdout.strip()
-        # keychain_token = bool(token_value)
+        if not resolved_token:
+            token_value = res.stdout.strip()
+            resolved_token = token_value
         
-        resolved_token = (res.stdout or "").strip()
         keychain_token = bool(resolved_token)
     except Exception:
         keychain_token = False
@@ -234,7 +248,7 @@ else:
         auth_kv = f"{auth_kv}:read_only"
     elif token_live_state == "valid" and token_permission_state == "write_capable":
         auth_kv = f"{auth_kv}:write_capable"
-    auth_memory_ready = token_live_state != "invalid" and token_live_state != "missing" and token_permission_state != "read_only"
+    auth_memory_ready = token_live_state == "valid" and token_permission_state == "write_capable"
     memory_layer = "ready" if fallback_state != "invalid" and auth_memory_ready else "degraded"
 #     memory_layer = "ready" if fallback_state != "invalid" else "degraded"
 #    memory_layer = "ready" if fallback_state != "invalid" and token_state == "ok" else "degraded"

--- a/tests/gm_status_test.sh
+++ b/tests/gm_status_test.sh
@@ -25,7 +25,7 @@ chmod +x "$TMP_DIR/gm-status"
 out="$(ROOT_DIR="$TMP_DIR" VALKYR_API_BASE="http://127.0.0.1:9/v1" VALKYR_AUTH_TOKEN=test "$TMP_DIR/gm-status")"
 
 echo "$out" | grep -q '^graymatter_auth=env$'
-echo "$out" | grep -q '^memory_layer=ready$'
+echo "$out" | grep -q '^memory_layer=degraded$'
 echo "$out" | grep -q '^graph_layer=ready$'
 echo "$out" | grep -q '^strategic_layer=ready$'
 echo "$out" | grep -q '^kpi_layer=ready$'


### PR DESCRIPTION
## Summary
- tighten  memory readiness so unknown/invalid live token states no longer report ready
- require a live valid + write-capable token before reporting 
- add keychain username-aware token lookup fallback in status checks
- update  to assert degraded state for unreachable auth validation

## Why
Issue #2570 reports stale keychain auth being surfaced as ready while writes fail. This change makes status conservative and truthful so stale/invalid sessions are flagged degraded.

## Validation
- gm_status_test: ok