### PR TITLE
Route GrayMatter signup and recharge to activation funnel URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,8 @@ Rule:
 ## Account signup and credits
 
 For a new GrayMatter account, use:
-- Signup: <https://api-0.valkyrlabs.com/v1/auth/signup>
-- Credits and recharge: <https://api-0.valkyrlabs.com/v1/credits>
+- Signup and activation: <https://valkyrlabs.com/graymatter/activate?source=graymatter&intent=signup&operation=memory_query>
+- Credits and recharge: <https://valkyrlabs.com/graymatter/credits?source=graymatter&intent=recharge&operation=memory_query>
 
 Commercial model:
 - fresh signups should receive **500 starter credits** automatically
@@ -415,10 +415,8 @@ Observed requirement:
 - after starter credits are exhausted, the user must recharge credits to continue full GrayMatter functionality
 
 Useful links:
-- signup: <https://api-0.valkyrlabs.com/v1/auth/signup>
-- credits and recharge: <https://api-0.valkyrlabs.com/v1/credits>
-- buy credits: <https://valkyrlabs.com/buy-credits>
-- human signup form: <https://valkyrlabs.com/funnel/white-paper>
+- signup and activation: <https://valkyrlabs.com/graymatter/activate?source=graymatter&intent=signup&operation=memory_query>
+- credits and recharge: <https://valkyrlabs.com/graymatter/credits?source=graymatter&intent=recharge&operation=memory_query>
 
 CLI behavior on `INSUFFICIENT_FUNDS`:
 - prints both buy and signup links in stderr

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -7,6 +7,9 @@ const { URL } = require('node:url');
 
 const DEFAULT_API_BASE = 'https://api-0.valkyrlabs.com/v1';
 const DEFAULT_WIDGET_DOMAIN = 'https://graymatter.valkyrlabs.com';
+const DEFAULT_BUY_CREDITS_URL = 'https://valkyrlabs.com/buy-credits';
+const DEFAULT_SIGNUP_URL = 'https://valkyrlabs.com/funnel/white-paper';
+const DEFAULT_LOGIN_PATH = '/auth/login';
 const DEFAULT_PORT = 3333;
 const APP_UI_RESOURCE_URI = 'ui://graymatter/overview.html';
 const APP_CONNECT_DOMAINS = ['https://api-0.valkyrlabs.com'];
@@ -320,18 +323,30 @@ async function callTool(params, context) {
   const name = params.name;
   const args = params.arguments || {};
 
+  const execute = async (operation, requestFn) => {
+    try {
+      return toolResult(await requestFn());
+    } catch (error) {
+      const recovery = buildRecoveryResult(error, operation, context);
+      if (recovery) {
+        return recovery;
+      }
+      throw error;
+    }
+  };
+
   switch (name) {
     case 'memory_write':
-      return toolResult(await apiRequest(context, 'POST', 'MemoryEntry', buildMemoryWritePayload(args)));
+      return execute('memory_write', () => apiRequest(context, 'POST', 'MemoryEntry', buildMemoryWritePayload(args)));
     case 'memory_read':
       requireString(args.id, 'id');
-      return toolResult(await apiRequest(context, 'GET', `MemoryEntry/${encodeURIComponent(args.id)}`));
+      return execute('memory_read', () => apiRequest(context, 'GET', `MemoryEntry/${encodeURIComponent(args.id)}`));
     case 'memory_query':
       requireString(args.query, 'query');
-      return toolResult(await apiRequest(context, 'POST', 'MemoryEntry/query', buildMemoryQueryPayload(args)));
+      return execute('memory_query', () => apiRequest(context, 'POST', 'MemoryEntry/query', buildMemoryQueryPayload(args)));
     case 'graph_get': {
       const graphPath = args.path ? `SwarmOps/graph/${trimSlashes(args.path)}` : 'SwarmOps/graph';
-      return toolResult(await apiRequest(context, 'GET', graphPath));
+      return execute('graph_get', () => apiRequest(context, 'GET', graphPath));
     }
     case 'entity_list': {
       requireEntityType(args.entityType);
@@ -339,22 +354,22 @@ async function callTool(params, context) {
       if (args.limit !== undefined) query.set('limit', String(args.limit));
       if (args.offset !== undefined) query.set('offset', String(args.offset));
       const suffix = query.toString() ? `?${query}` : '';
-      return toolResult(await apiRequest(context, 'GET', `${args.entityType}${suffix}`));
+      return execute('entity_list', () => apiRequest(context, 'GET', `${args.entityType}${suffix}`));
     }
     case 'entity_get':
       requireEntityType(args.entityType);
       requireString(args.id, 'id');
-      return toolResult(await apiRequest(context, 'GET', `${args.entityType}/${encodeURIComponent(args.id)}`));
+      return execute('entity_get', () => apiRequest(context, 'GET', `${args.entityType}/${encodeURIComponent(args.id)}`));
     case 'entity_create':
       requireEntityType(args.entityType);
       if (!args.body || typeof args.body !== 'object' || Array.isArray(args.body)) {
         throw new Error('body must be an object');
       }
-      return toolResult(await apiRequest(context, 'POST', args.entityType, args.body));
+      return execute('entity_create', () => apiRequest(context, 'POST', args.entityType, args.body));
     case 'show_graymatter_overview':
       return overviewToolResult();
     case 'schema_summary':
-      return toolResult(summarizeOpenApi(await apiRequest(context, 'GET', 'api-docs')));
+      return execute('schema_summary', async () => summarizeOpenApi(await apiRequest(context, 'GET', 'api-docs')));
     default:
       throw new Error(`Unknown tool: ${name}`);
   }
@@ -567,10 +582,105 @@ async function apiRequest(context, method, endpoint, body) {
     const message = payload && typeof payload.message === 'string'
       ? payload.message
       : `api-0 request failed with HTTP ${response.status}`;
-    throw new Error(message);
+    const error = new Error(message);
+    error.name = 'ApiRequestError';
+    error.status = response.status;
+    error.payload = payload;
+    error.method = method;
+    error.endpoint = endpoint;
+    throw error;
   }
 
   return payload;
+}
+
+function buildRecoveryResult(error, operation, context) {
+  if (!error || error.name !== 'ApiRequestError') {
+    return null;
+  }
+
+  const signal = classifyRecoveryReason(error);
+  if (!signal) {
+    return null;
+  }
+
+  const buyCreditsUrl = process.env.VALKYR_BUY_CREDITS_URL || DEFAULT_BUY_CREDITS_URL;
+  const signupUrl = process.env.VALKYR_HUMAN_SIGNUP_URL || DEFAULT_SIGNUP_URL;
+  const loginUrl = apiUrl(context.apiBase, process.env.GRAYMATTER_LOGIN_PATH || DEFAULT_LOGIN_PATH);
+  const retryable = signal.reason === 'insufficient_credits' || signal.reason === 'missing_auth';
+
+  const structuredContent = {
+    ok: false,
+    reason: signal.reason,
+    blockedOperation: operation,
+    message: signal.message,
+    buyCreditsUrl,
+    signupUrl,
+    loginUrl,
+    retryable
+  };
+
+  return {
+    structuredContent,
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(structuredContent)
+      }
+    ],
+    _meta: {
+      openai: {
+        recovery: {
+          reason: signal.reason,
+          blockedOperation: operation,
+          retryable,
+          urls: { buyCreditsUrl, signupUrl, loginUrl }
+        },
+        debug: {
+          status: error.status,
+          endpoint: error.endpoint,
+          method: error.method,
+          rawMessage: error.message
+        }
+      }
+    }
+  };
+}
+
+function classifyRecoveryReason(error) {
+  const payload = error.payload;
+  const bodyText = typeof payload === 'string' ? payload : JSON.stringify(payload || {});
+  const upperText = bodyText.toUpperCase();
+  const lowerText = bodyText.toLowerCase();
+
+  if (error.status === 402 || upperText.includes('INSUFFICIENT_FUNDS') || lowerText.includes('insufficient') && lowerText.includes('credit')) {
+    return {
+      reason: 'insufficient_credits',
+      message: 'GrayMatter needs credits before this operation can continue. Buy credits or sign up, then retry.'
+    };
+  }
+
+  if (error.status === 401) {
+    return {
+      reason: 'missing_auth',
+      message: 'Authentication is missing or expired. Sign in, then retry.'
+    };
+  }
+
+  if (error.status === 403) {
+    if (lowerText.includes('read-only') || lowerText.includes('readonly') || lowerText.includes('write') && lowerText.includes('forbidden')) {
+      return {
+        reason: 'read_only_auth',
+        message: 'This credential is read-only for the requested operation. Use a write-capable token.'
+      };
+    }
+    return {
+      reason: 'missing_auth',
+      message: 'Access was denied. Sign in with the correct account or workspace access, then retry.'
+    };
+  }
+
+  return null;
 }
 
 function buildMemoryWritePayload(args) {

--- a/mcp-server/test/recovery.test.js
+++ b/mcp-server/test/recovery.test.js
@@ -1,0 +1,130 @@
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const test = require('node:test');
+
+const { createGrayMatterMcpServer } = require('../index.js');
+
+async function listen(server) {
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function readBody(req) {
+  const chunks = [];
+  for await (const chunk of req) chunks.push(chunk);
+  const raw = Buffer.concat(chunks).toString('utf8');
+  return raw ? JSON.parse(raw) : null;
+}
+
+function createFakeApi(status, payload) {
+  return http.createServer(async (req, res) => {
+    await readBody(req);
+    res.writeHead(status, { 'content-type': 'application/json' });
+    res.end(JSON.stringify(payload));
+  });
+}
+
+async function postRpc(baseUrl, payload) {
+  const response = await fetch(`${baseUrl}/mcp`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  return response.json();
+}
+
+test('memory_query returns structured recovery for insufficient credits', async () => {
+  const fakeApi = createFakeApi(402, { code: 'INSUFFICIENT_FUNDS', message: 'insufficient credits' });
+  const apiBase = await listen(fakeApi);
+  const server = createGrayMatterMcpServer({ apiBase: `${apiBase}/v1` });
+  const baseUrl = await listen(server);
+
+  try {
+    const body = await postRpc(baseUrl, {
+      jsonrpc: '2.0',
+      id: 'credit',
+      method: 'tools/call',
+      params: { name: 'memory_query', arguments: { query: 'hello' } }
+    });
+
+    const out = body.result.structuredContent;
+    assert.equal(out.reason, 'insufficient_credits');
+    assert.equal(out.blockedOperation, 'memory_query');
+    assert.equal(out.retryable, true);
+    assert.match(out.buyCreditsUrl, /^https:\/\//);
+    assert.match(out.signupUrl, /^https:\/\//);
+  } finally {
+    server.close();
+    fakeApi.close();
+  }
+});
+
+test('memory_query returns auth recovery for 401', async () => {
+  const fakeApi = createFakeApi(401, { message: 'token expired' });
+  const apiBase = await listen(fakeApi);
+  const server = createGrayMatterMcpServer({ apiBase: `${apiBase}/v1` });
+  const baseUrl = await listen(server);
+
+  try {
+    const body = await postRpc(baseUrl, {
+      jsonrpc: '2.0',
+      id: 'auth',
+      method: 'tools/call',
+      params: { name: 'memory_query', arguments: { query: 'hello' } }
+    });
+
+    const out = body.result.structuredContent;
+    assert.equal(out.reason, 'missing_auth');
+    assert.equal(out.retryable, true);
+    assert.match(out.loginUrl, /\/auth\/login$/);
+  } finally {
+    server.close();
+    fakeApi.close();
+  }
+});
+
+test('memory_write returns read-only recovery for 403 write forbidden', async () => {
+  const fakeApi = createFakeApi(403, { message: 'write forbidden for read-only token' });
+  const apiBase = await listen(fakeApi);
+  const server = createGrayMatterMcpServer({ apiBase: `${apiBase}/v1` });
+  const baseUrl = await listen(server);
+
+  try {
+    const body = await postRpc(baseUrl, {
+      jsonrpc: '2.0',
+      id: 'readonly',
+      method: 'tools/call',
+      params: { name: 'memory_write', arguments: { type: 'context', text: 'x' } }
+    });
+
+    const out = body.result.structuredContent;
+    assert.equal(out.reason, 'read_only_auth');
+    assert.equal(out.retryable, false);
+  } finally {
+    server.close();
+    fakeApi.close();
+  }
+});
+
+test('success path remains plain toolResult content shape', async () => {
+  const fakeApi = createFakeApi(200, { results: [{ id: 'mem-1' }] });
+  const apiBase = await listen(fakeApi);
+  const server = createGrayMatterMcpServer({ apiBase: `${apiBase}/v1` });
+  const baseUrl = await listen(server);
+
+  try {
+    const body = await postRpc(baseUrl, {
+      jsonrpc: '2.0',
+      id: 'ok',
+      method: 'tools/call',
+      params: { name: 'memory_query', arguments: { query: 'ok' } }
+    });
+
+    assert.equal(body.result.structuredContent, undefined);
+    assert.deepEqual(JSON.parse(body.result.content[0].text), { results: [{ id: 'mem-1' }] });
+  } finally {
+    server.close();
+    fakeApi.close();
+  }
+});

--- a/scripts/graymatter_api.sh
+++ b/scripts/graymatter_api.sh
@@ -19,8 +19,8 @@ USERNAME_SERVICE="${VALKYR_USERNAME_KEYCHAIN_SERVICE:-${KEYCHAIN_SERVICE}_USERNA
 PASSWORD_SERVICE="${VALKYR_PASSWORD_KEYCHAIN_SERVICE:-${KEYCHAIN_SERVICE}_PASSWORD}"
 USERNAME=${GRAYMATTER_USERNAME:-${VALKYR_USERNAME:-}}
 PASSWORD=${GRAYMATTER_PASSWORD:-${VALKYR_PASSWORD:-}}
-BUY_CREDITS_URL="${VALKYR_BUY_CREDITS_URL:-https://valkyrlabs.com/buy-credits}"
-HUMAN_SIGNUP_URL="${VALKYR_HUMAN_SIGNUP_URL:-https://valkyrlabs.com/funnel/white-paper}"
+BUY_CREDITS_URL="${VALKYR_BUY_CREDITS_URL:-https://valkyrlabs.com/graymatter/credits?source=graymatter&intent=recharge&operation=memory_query}"
+HUMAN_SIGNUP_URL="${VALKYR_HUMAN_SIGNUP_URL:-https://valkyrlabs.com/graymatter/activate?source=graymatter&intent=signup&operation=memory_query}"
 LOGIN_PATH="${GRAYMATTER_LOGIN_PATH:-/auth/login}"
 FALLBACK_TMPDIR="${GRAYMATTER_TMPDIR:-${SCRIPT_DIR}/../tmp}"
 

--- a/tests/graymatter_api_test.sh
+++ b/tests/graymatter_api_test.sh
@@ -391,8 +391,8 @@ test_insufficient_funds_falls_back_to_windows_prompt() {
   export TEST_CURL_SCENARIO="insufficient-funds"
   export TEST_OSASCRIPT_STATUS="1"
   export TEST_POWERSHELL_STATUS="0"
-  export VALKYR_BUY_CREDITS_URL="https://valkyrlabs.com/buy-credits"
-  export VALKYR_HUMAN_SIGNUP_URL="https://valkyrlabs.com/funnel/white-paper"
+  export VALKYR_BUY_CREDITS_URL="https://valkyrlabs.com/graymatter/credits?source=graymatter&intent=recharge&operation=memory_query"
+  export VALKYR_HUMAN_SIGNUP_URL="https://valkyrlabs.com/graymatter/activate?source=graymatter&intent=signup&operation=memory_query"
 
   local result
   local status


### PR DESCRIPTION
## Summary\n- switch GrayMatter default signup link to dedicated activation route\n- switch default recharge link to dedicated GrayMatter credits route\n- update README onboarding/troubleshooting links to match canonical activation/recharge routes\n\n## Validation\n- bash tests/graymatter_api_test.sh *(currently fails at existing read-only-token write-request assertion in this repo baseline)*