### PR TITLE
fix(auth): use stateful GrayMatter writes

### DIFF
--- a/scripts/gm-write
+++ b/scripts/gm-write
@@ -190,13 +190,13 @@ if jq -e 'length > 2 or ((has("runtime") and has("sourceChannel")) | not)' <<<"$
 fi
 
 if [[ -n "$TAGS_RAW" ]]; then
-  PAYLOAD="$(jq -nc --arg type "$TYPE" --arg text "$TEXT" --arg sourceChannel "$SOURCE_CHANNEL" --arg tagsRaw "$TAGS_RAW" '{type:$type,text:$text,sourceChannel:$sourceChannel,tags:($tagsRaw | split(",") | map(gsub("^\\s+|\\s+$";"")) | map(select(length > 0)))}')"
+  PAYLOAD="$(jq -nc --arg type "$TYPE" --arg text "$TEXT" --arg sourceChannel "$SOURCE_CHANNEL" --arg tagsRaw "$TAGS_RAW" '{type:$type,text:$text,source:$sourceChannel,tags:($tagsRaw | split(",") | map(gsub("^\\s+|\\s+$";"")) | map(select(length > 0)))}')"
 else
-  PAYLOAD="$(jq -nc --arg type "$TYPE" --arg text "$TEXT" --arg sourceChannel "$SOURCE_CHANNEL" '{type:$type,text:$text,sourceChannel:$sourceChannel}')"
+  PAYLOAD="$(jq -nc --arg type "$TYPE" --arg text "$TEXT" --arg sourceChannel "$SOURCE_CHANNEL" '{type:$type,text:$text,source:$sourceChannel}')"
 fi
 
 set +e
-RESPONSE="$(${SCRIPT_DIR}/graymatter_api.sh POST /MemoryEntry "$PAYLOAD" 2>&1)"
+RESPONSE="$(${SCRIPT_DIR}/graymatter_api.sh POST /MemoryEntry/write "$PAYLOAD" 2>&1)"
 STATUS=$?
 set -e
 
@@ -207,8 +207,8 @@ fi
 
 if [[ -n "$TAGS_RAW" ]] && printf '%s' "$RESPONSE" | grep -Eqi 'tags|tag|relation'; then
   echo "Tagged write failed, retrying without tags due to backend tag persistence issue" >&2
-  FALLBACK_PAYLOAD="$(jq -nc --arg type "$TYPE" --arg text "$TEXT" --arg sourceChannel "$SOURCE_CHANNEL" '{type:$type,text:$text,sourceChannel:$sourceChannel}')"
-  exec "${SCRIPT_DIR}/graymatter_api.sh" POST /MemoryEntry "$FALLBACK_PAYLOAD"
+  FALLBACK_PAYLOAD="$(jq -nc --arg type "$TYPE" --arg text "$TEXT" --arg sourceChannel "$SOURCE_CHANNEL" '{type:$type,text:$text,source:$sourceChannel}')"
+  exec "${SCRIPT_DIR}/graymatter_api.sh" POST /MemoryEntry/write "$FALLBACK_PAYLOAD"
 fi
 
 TEXT_LEN=${#TEXT}

--- a/scripts/graymatter_api.sh
+++ b/scripts/graymatter_api.sh
@@ -265,9 +265,14 @@ elseif ($result -eq "No") { Start-Process $signupUrl }
 
 RESPONSE_FILE="$(portable_mktemp graymatter-response.XXXXXX)"
 RESPONSE_HEADERS="$(portable_mktemp graymatter-headers.XXXXXX)"
+STATEFUL_COOKIE_JAR=""
+STATEFUL_XSRF_TOKEN=""
 cleanup() {
   rm -f "$RESPONSE_FILE"
   rm -f "$RESPONSE_HEADERS"
+  if [[ -n "$STATEFUL_COOKIE_JAR" ]]; then
+    rm -f "$STATEFUL_COOKIE_JAR"
+  fi
 }
 trap cleanup EXIT
 
@@ -349,6 +354,54 @@ refresh_token() {
   return 0
 }
 
+prepare_stateful_auth_for_write() {
+  if [[ -z "$USERNAME" || -z "$PASSWORD" || "$LIGHT_MODE" == "true" ]]; then
+    return 1
+  fi
+
+  local login_body
+  local login_headers
+  local login_status
+  login_body="$(portable_mktemp graymatter-login-body.XXXXXX)"
+  login_headers="$(portable_mktemp graymatter-login-headers.XXXXXX)"
+  STATEFUL_COOKIE_JAR="$(portable_mktemp graymatter-login-cookie.XXXXXX)"
+
+  set +e
+  login_status="$(
+    curl -sS \
+      --connect-timeout "$CURL_CONNECT_TIMEOUT" \
+      --max-time "$CURL_MAX_TIME" \
+      -o "$login_body" -D "$login_headers" -c "$STATEFUL_COOKIE_JAR" \
+      -w "%{http_code}" \
+      -X POST "${BASE%/}/${LOGIN_PATH#/}" \
+      -H "accept: application/json" \
+      -H "content-type: application/json" \
+      --data "$(jq -nc --arg username "$USERNAME" --arg password "$PASSWORD" '{username:$username,password:$password}')"
+  )"
+  local curl_status=$?
+  set -e
+
+  if (( curl_status != 0 )) || [[ ! "$login_status" =~ ^[0-9]{3}$ ]] || (( login_status >= 400 )); then
+    rm -f "$login_body" "$login_headers"
+    return 1
+  fi
+
+  local refreshed_token
+  refreshed_token=$(extract_token_from_login_response "$login_body" "$login_headers")
+  if [[ -z "$refreshed_token" && -s "$STATEFUL_COOKIE_JAR" ]]; then
+    refreshed_token=$(awk '$6 == "VALKYR_AUTH" {print $7}' "$STATEFUL_COOKIE_JAR" | tail -n 1)
+  fi
+  STATEFUL_XSRF_TOKEN="$(awk '$6 == "XSRF-TOKEN" {print $7}' "$STATEFUL_COOKIE_JAR" | tail -n 1)"
+  rm -f "$login_body" "$login_headers"
+
+  if [[ -n "$refreshed_token" ]]; then
+    TOKEN=$refreshed_token
+    store_token "$TOKEN"
+  fi
+
+  [[ -s "$STATEFUL_COOKIE_JAR" && -n "$STATEFUL_XSRF_TOKEN" ]]
+}
+
 if [[ -n "$TOKEN" ]] && token_expires_soon "$TOKEN"; then
   if refresh_token && [[ -n "$TOKEN" ]] && ! token_expires_soon "$TOKEN"; then
     :
@@ -375,7 +428,16 @@ perform_request() {
     COMMON_HEADERS+=(
       -H "Authorization: Bearer ${TOKEN}"
       -H "VALKYR_AUTH: ${TOKEN}"
-      -H "Cookie: VALKYR_AUTH=${TOKEN}"
+    )
+    if [[ -z "$STATEFUL_COOKIE_JAR" ]]; then
+      COMMON_HEADERS+=(
+        -H "Cookie: VALKYR_AUTH=${TOKEN}"
+      )
+    fi
+  fi
+  if [[ -n "$STATEFUL_XSRF_TOKEN" ]]; then
+    COMMON_HEADERS+=(
+      -H "X-XSRF-TOKEN: ${STATEFUL_XSRF_TOKEN}"
     )
   fi
 
@@ -391,6 +453,12 @@ perform_request() {
     "${COMMON_HEADERS[@]}"
   )
 
+  if [[ -n "$STATEFUL_COOKIE_JAR" && -s "$STATEFUL_COOKIE_JAR" ]]; then
+    CURL_ARGS+=(
+      -b "$STATEFUL_COOKIE_JAR"
+    )
+  fi
+
   if [[ -n "$BODY" ]]; then
     CURL_ARGS+=(
       -H "content-type: application/json"
@@ -403,6 +471,10 @@ perform_request() {
   CURL_STATUS=$?
   set -e
 }
+
+if method_requires_write_access; then
+  prepare_stateful_auth_for_write || true
+fi
 
 perform_request
 


### PR DESCRIPTION
## Summary
- use fresh login cookie + XSRF token for mutating GrayMatter API requests
- avoid overriding cookie-jar auth with a manual Cookie header during stateful writes
- route gm-write through `/MemoryEntry/write` using the documented `source` field

## Verification
- `bash -n scripts/graymatter_api.sh scripts/gm-write`
- `./scripts/gm-status` → `graymatter_auth=keychain:write_capable`, `memory_layer=ready`
- `./scripts/gm-install-check` → passed
- `./scripts/gm-smoke` → passed
- `./scripts/gm-query "GrayMatter smoke test" 3` → passed
- `./scripts/gm-register-agent "$(hostname)-retry-all" Valor openclaw-server` → passed
- `./scripts/gm-openapi-sync` and `./scripts/gm-openapi-summary` → passed

## Notes
Before this patch, bearer/header-only POSTs returned `SESSION_EXPIRED`; cookie+XSRF stateful requests succeeded.