### PR TITLE
[codex] fix autonomous auth refresh for GrayMatter MCP

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -28,6 +28,8 @@ The repo-level `.mcp.json` points Codex at `node mcp-server/index.js --stdio`.
 | --- | --- | --- | --- |
 | `VALKYR_AUTH_TOKEN` | Recommended | none | Bearer token from `scripts/gm-login`. Can also be passed per request through `X-Valkyr-Token`. |
 | `VALKYR_API_BASE` | No | `https://api-0.valkyrlabs.com/v1` | API base to target. Use hosted api-0, a self-hosted api-0, or a local GrayMatter Light ThorAPI instance. |
+| `GRAYMATTER_LOGIN_COMMAND` | No | `../scripts/gm-login` | Login helper used to refresh process-scoped auth after api-0 returns `SESSION_EXPIRED`. |
+| `GRAYMATTER_LOGIN_TIMEOUT_MS` | No | `30000` | Maximum time allowed for the autonomous login helper during MCP auth recovery. |
 | `GRAYMATTER_WIDGET_DOMAIN` | No | `https://graymatter.valkyrlabs.com` | Public widget origin advertised in Apps SDK resource metadata for ChatGPT app review. |
 | `PORT` | No | `3333` | HTTP port to listen on. |
 
@@ -123,6 +125,8 @@ Add an HTTP MCP server entry that points at the message endpoint:
 ## Per-Request Auth
 
 For multi-tenant deployments, do not set a shared `VALKYR_AUTH_TOKEN`. Pass each user's token through `X-Valkyr-Token` so all api-0 calls stay scoped to that user's RBAC permissions.
+
+When the server is using process-scoped auth from `VALKYR_AUTH_TOKEN`, `VALKYR_JWT_SESSION`, or the plugin launch environment, a `401 SESSION_EXPIRED` response triggers one autonomous `gm-login env` refresh and retries the original request with the new token. Per-request `X-Valkyr-Token` or bearer credentials are never replaced by process credentials, so tenant-scoped calls remain isolated.
 
 ## Production Notes
 

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -3,6 +3,8 @@
 
 const http = require('node:http');
 const readline = require('node:readline');
+const { execFileSync } = require('node:child_process');
+const path = require('node:path');
 const { URL } = require('node:url');
 
 const DEFAULT_API_BASE = 'https://api-0.valkyrlabs.com/v1';
@@ -183,6 +185,9 @@ function createGrayMatterMcpServer(options = {}) {
   const apiBase = withoutTrailingSlash(options.apiBase || process.env.VALKYR_API_BASE || DEFAULT_API_BASE);
   const widgetDomain = withoutTrailingSlash(options.widgetDomain || process.env.GRAYMATTER_WIDGET_DOMAIN || DEFAULT_WIDGET_DOMAIN);
   const fetchImpl = options.fetch || globalThis.fetch;
+  const loginProvider = options.loginProvider || runLoginCommand;
+  const loginCommand = options.loginCommand || process.env.GRAYMATTER_LOGIN_COMMAND || path.join(__dirname, '..', 'scripts', 'gm-login');
+  const processToken = options.token || process.env.VALKYR_AUTH_TOKEN || process.env.VALKYR_JWT_SESSION || '';
 
   if (typeof fetchImpl !== 'function') {
     throw new Error('Global fetch is required. Use Node 20 or newer.');
@@ -216,7 +221,9 @@ function createGrayMatterMcpServer(options = {}) {
         const rpcResponse = await handleRpc(rpcRequest, {
           apiBase,
           fetchImpl,
-          token: authTokenFrom(req),
+          ...authContextFrom(req, processToken),
+          loginCommand,
+          loginProvider,
           widgetDomain
         });
 
@@ -240,6 +247,8 @@ function createRpcContext(options = {}) {
   const apiBase = withoutTrailingSlash(options.apiBase || process.env.VALKYR_API_BASE || DEFAULT_API_BASE);
   const widgetDomain = withoutTrailingSlash(options.widgetDomain || process.env.GRAYMATTER_WIDGET_DOMAIN || DEFAULT_WIDGET_DOMAIN);
   const fetchImpl = options.fetch || globalThis.fetch;
+  const loginProvider = options.loginProvider || runLoginCommand;
+  const loginCommand = options.loginCommand || process.env.GRAYMATTER_LOGIN_COMMAND || path.join(__dirname, '..', 'scripts', 'gm-login');
 
   if (typeof fetchImpl !== 'function') {
     throw new Error('Global fetch is required. Use Node 20 or newer.');
@@ -249,6 +258,9 @@ function createRpcContext(options = {}) {
     apiBase,
     fetchImpl,
     token: options.token || process.env.VALKYR_AUTH_TOKEN || process.env.VALKYR_JWT_SESSION || '',
+    requestScopedToken: false,
+    loginCommand,
+    loginProvider,
     widgetDomain
   };
 }
@@ -556,6 +568,17 @@ function overviewWidgetHtml() {
 }
 
 async function apiRequest(context, method, endpoint, body) {
+  try {
+    return await apiRequestOnce(context, method, endpoint, body);
+  } catch (error) {
+    if (!isRefreshableAuthError(error) || !(await refreshAuth(context))) {
+      throw error;
+    }
+    return apiRequestOnce(context, method, endpoint, body);
+  }
+}
+
+async function apiRequestOnce(context, method, endpoint, body) {
   const headers = {
     accept: 'application/json'
   };
@@ -592,6 +615,66 @@ async function apiRequest(context, method, endpoint, body) {
   }
 
   return payload;
+}
+
+async function refreshAuth(context) {
+  if (!context || context.requestScopedToken || typeof context.loginProvider !== 'function') {
+    return false;
+  }
+
+  try {
+    const token = await context.loginProvider(context);
+    if (!token || typeof token !== 'string') {
+      return false;
+    }
+    context.token = token;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isRefreshableAuthError(error) {
+  if (!error || error.name !== 'ApiRequestError' || error.status !== 401) {
+    return false;
+  }
+
+  const payload = error.payload;
+  const text = typeof payload === 'string' ? payload : JSON.stringify(payload || {});
+  return /SESSION_EXPIRED|TOKEN_EXPIRED|expired|missing auth|unauthorized/i.test(text);
+}
+
+function runLoginCommand(context) {
+  const loginCommand = context.loginCommand || process.env.GRAYMATTER_LOGIN_COMMAND || path.join(__dirname, '..', 'scripts', 'gm-login');
+  const output = execFileSync(loginCommand, ['env'], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      VALKYR_API_BASE: context.apiBase
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: Number(process.env.GRAYMATTER_LOGIN_TIMEOUT_MS || 30000)
+  });
+  return parseExportedToken(output);
+}
+
+function parseExportedToken(output) {
+  const text = String(output || '');
+  const patterns = [
+    /^export\s+VALKYR_AUTH_TOKEN="([^"]+)"$/m,
+    /^export\s+VALKYR_JWT_SESSION="([^"]+)"$/m,
+    /^VALKYR_AUTH_TOKEN=([^\n]+)$/m,
+    /^VALKYR_JWT_SESSION=([^\n]+)$/m
+  ];
+
+  for (const pattern of patterns) {
+    const match = text.match(pattern);
+    if (match && match[1]) {
+      return match[1].trim();
+    }
+  }
+
+  return '';
 }
 
 function buildRecoveryResult(error, operation, context) {
@@ -852,13 +935,13 @@ function summarizeOpenApi(spec) {
   };
 }
 
-function authTokenFrom(req) {
+function authContextFrom(req, processToken = '') {
   const headerToken = req.headers['x-valkyr-token'];
   if (Array.isArray(headerToken)) {
-    return headerToken[0] || process.env.VALKYR_AUTH_TOKEN || '';
+    return { token: headerToken[0] || '', requestScopedToken: Boolean(headerToken[0]) };
   }
   if (headerToken) {
-    return headerToken;
+    return { token: headerToken, requestScopedToken: true };
   }
 
   const authHeader = Array.isArray(req.headers.authorization)
@@ -866,10 +949,10 @@ function authTokenFrom(req) {
     : req.headers.authorization;
   const bearerMatch = typeof authHeader === 'string' ? authHeader.match(/^Bearer\s+(.+)$/i) : null;
   if (bearerMatch) {
-    return bearerMatch[1].trim();
+    return { token: bearerMatch[1].trim(), requestScopedToken: true };
   }
 
-  return process.env.VALKYR_AUTH_TOKEN || '';
+  return { token: processToken || process.env.VALKYR_AUTH_TOKEN || process.env.VALKYR_JWT_SESSION || '', requestScopedToken: false };
 }
 
 function apiUrl(apiBase, endpoint) {

--- a/mcp-server/test/recovery.test.js
+++ b/mcp-server/test/recovery.test.js
@@ -63,7 +63,10 @@ test('memory_query returns structured recovery for insufficient credits', async 
 test('memory_query returns auth recovery for 401', async () => {
   const fakeApi = createFakeApi(401, { message: 'token expired' });
   const apiBase = await listen(fakeApi);
-  const server = createGrayMatterMcpServer({ apiBase: `${apiBase}/v1` });
+  const server = createGrayMatterMcpServer({
+    apiBase: `${apiBase}/v1`,
+    loginProvider: async () => ''
+  });
   const baseUrl = await listen(server);
 
   try {

--- a/mcp-server/test/server.test.js
+++ b/mcp-server/test/server.test.js
@@ -462,8 +462,111 @@ test('Apps SDK bearer auth is accepted on /mcp and forwarded to api-0', async ()
 
     res.writeHead(200, { 'content-type': 'application/json' });
     res.end(JSON.stringify({ id: 'mem-99' }));
+  });
+
+  const apiBase = await listen(fakeApi.server);
+  const server = createGrayMatterMcpServer({ apiBase: `${apiBase}/v1` });
+  const baseUrl = await listen(server);
+
+  try {
+    const result = await postRpc(baseUrl, {
+      jsonrpc: '2.0',
+      id: 'bearer-auth',
+      method: 'tools/call',
+      params: { name: 'memory_read', arguments: { id: 'mem-99' } }
+    }, { authorization: 'Bearer apps-sdk-token' }, '/mcp');
+
+    assert.equal(result.status, 200);
+    assert.equal(result.body.result.content[0].text, JSON.stringify({ id: 'mem-99' }));
+    assert.equal(fakeApi.requests.length, 1);
+  } finally {
+    server.close();
+    fakeApi.server.close();
+  }
 });
-                                
+
+test('MCP process auth reauthenticates once on SESSION_EXPIRED and retries', async () => {
+  const fakeApi = createFakeApi(async (_req, res, record) => {
+    if (fakeApi.requests.length === 1) {
+      assert.equal(record.headers.authorization, 'Bearer expired-process-token');
+      res.writeHead(401, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({
+        error: 'SESSION_EXPIRED',
+        message: 'Session expired or replaced by another login. Please sign in again to obtain a fresh token.'
+      }));
+      return;
+    }
+
+    assert.equal(record.headers.authorization, 'Bearer refreshed-process-token');
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ id: 'mem-99', recovered: true }));
+  });
+
+  const apiBase = await listen(fakeApi.server);
+  const server = createGrayMatterMcpServer({
+    apiBase: `${apiBase}/v1`,
+    token: 'expired-process-token',
+    loginProvider: async () => 'refreshed-process-token'
+  });
+  const baseUrl = await listen(server);
+
+  try {
+    const result = await postRpc(baseUrl, {
+      jsonrpc: '2.0',
+      id: 'reauth',
+      method: 'tools/call',
+      params: { name: 'memory_read', arguments: { id: 'mem-99' } }
+    }, {}, '/mcp');
+
+    assert.equal(result.status, 200);
+    assert.equal(result.body.result.content[0].text, JSON.stringify({ id: 'mem-99', recovered: true }));
+    assert.equal(fakeApi.requests.length, 2);
+  } finally {
+    server.close();
+    fakeApi.server.close();
+  }
+});
+
+test('MCP per-request auth does not reauthenticate into a shared process token', async () => {
+  let loginCalls = 0;
+  const fakeApi = createFakeApi(async (_req, res, record) => {
+    assert.equal(record.headers.authorization, 'Bearer expired-user-token');
+    res.writeHead(401, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({
+      error: 'SESSION_EXPIRED',
+      message: 'Session expired for this caller.'
+    }));
+  });
+
+  const apiBase = await listen(fakeApi.server);
+  const server = createGrayMatterMcpServer({
+    apiBase: `${apiBase}/v1`,
+    token: 'process-token',
+    loginProvider: async () => {
+      loginCalls += 1;
+      return 'refreshed-process-token';
+    }
+  });
+  const baseUrl = await listen(server);
+
+  try {
+    const result = await postRpc(baseUrl, {
+      jsonrpc: '2.0',
+      id: 'request-scoped-expired',
+      method: 'tools/call',
+      params: { name: 'memory_read', arguments: { id: 'mem-99' } }
+    }, { authorization: 'Bearer expired-user-token' }, '/mcp');
+
+    assert.equal(result.status, 200);
+    assert.equal(result.body.result.structuredContent.reason, 'missing_auth');
+    assert.equal(loginCalls, 0);
+    assert.equal(fakeApi.requests.length, 1);
+  } finally {
+    server.close();
+    fakeApi.server.close();
+  }
+});
+
 test('memory tools derive scoped sourceChannel from Codex hierarchy metadata', async () => {
   const automationPath = '/tmp/codex-home/.codex/automations/mcp-and-skill-hunter/memory.md';
   const fakeApi = createFakeApi(async (_req, res, record) => {
@@ -494,16 +597,6 @@ test('memory tools derive scoped sourceChannel from Codex hierarchy metadata', a
   const baseUrl = await listen(server);
 
   try {
-    const result = await postRpc(baseUrl, {
-      jsonrpc: '2.0',
-      id: 'bearer-auth',
-      method: 'tools/call',
-      params: { name: 'memory_read', arguments: { id: 'mem-99' } }
-    }, { authorization: 'Bearer apps-sdk-token' }, '/mcp');
-
-    assert.equal(result.status, 200);
-    assert.equal(result.body.result.content[0].text, JSON.stringify({ id: 'mem-99' }));
-    assert.equal(fakeApi.requests.length, 1);
     const writeResult = await postRpc(baseUrl, {
       jsonrpc: '2.0',
       id: 'scoped-write',

--- a/scripts/gm-login
+++ b/scripts/gm-login
@@ -272,12 +272,21 @@ store_keychain() {
     echo "macOS security CLI not available for keychain mode" >&2
     exit 3
   fi
-  security add-generic-password -U -a "$USERNAME" -s "$KEYCHAIN_SERVICE" -w "$AUTH_TOKEN" >/dev/null
-  security add-generic-password -U -a default -s "$KEYCHAIN_SERVICE" -w "$AUTH_TOKEN" >/dev/null
-  security add-generic-password -U -a default -s "$USERNAME_SERVICE" -w "$USERNAME" >/dev/null
-  security add-generic-password -U -a "$USERNAME" -s "$PASSWORD_SERVICE" -w "$PASSWORD" >/dev/null
+  replace_keychain_secret "$USERNAME" "$KEYCHAIN_SERVICE" "$AUTH_TOKEN"
+  replace_keychain_secret default "$KEYCHAIN_SERVICE" "$AUTH_TOKEN"
+  replace_keychain_secret default "$USERNAME_SERVICE" "$USERNAME"
+  replace_keychain_secret "$USERNAME" "$PASSWORD_SERVICE" "$PASSWORD"
   echo "Stored GrayMatter VALKYR_AUTH token securely in macOS/iCloud Keychain service ${KEYCHAIN_SERVICE}" >&2
   echo "Stored GrayMatter credentials securely in macOS/iCloud Keychain" >&2
+}
+
+replace_keychain_secret() {
+  local account="$1"
+  local service="$2"
+  local value="$3"
+
+  security delete-generic-password -a "$account" -s "$service" >/dev/null 2>&1 || true
+  security add-generic-password -U -a "$account" -s "$service" -w "$value" >/dev/null
 }
 
 case "$OUT_MODE" in

--- a/scripts/graymatter_api.sh
+++ b/scripts/graymatter_api.sh
@@ -150,9 +150,18 @@ store_token() {
     return 0
   fi
   if [[ -n "$USERNAME" ]]; then
-    security add-generic-password -U -a "$USERNAME" -s "$KEYCHAIN_SERVICE" -w "$token" >/dev/null
+    replace_keychain_secret "$USERNAME" "$KEYCHAIN_SERVICE" "$token"
   fi
-  security add-generic-password -U -a default -s "$KEYCHAIN_SERVICE" -w "$token" >/dev/null
+  replace_keychain_secret default "$KEYCHAIN_SERVICE" "$token"
+}
+
+replace_keychain_secret() {
+  local account="$1"
+  local service="$2"
+  local value="$3"
+
+  security delete-generic-password -a "$account" -s "$service" >/dev/null 2>&1 || true
+  security add-generic-password -U -a "$account" -s "$service" -w "$value" >/dev/null
 }
 
 run_login() {


### PR DESCRIPTION
## Summary
- add autonomous MCP process-auth refresh after api-0 returns `SESSION_EXPIRED`, using `gm-login env` and retrying the original request once
- preserve tenant isolation by refusing to replace per-request `X-Valkyr-Token` or bearer credentials with shared process credentials
- replace Keychain token aliases before storing refreshed GrayMatter auth so stale `default/VALKYR_AUTH` entries do not keep poisoning downstream agents
- document the MCP auth recovery env vars and behavior

## Validation
- `npm test` in `mcp-server`
- `tests/graymatter_api_test.sh && bash tests/gm_login_test.sh && tests/gm_install_check_test.sh`
- full shell test sweep with `for t in tests/*_test.sh; do bash "$t"; done` completed with exit 0; local server runtime check printed Java Runtime unavailable but continued non-fatally
- live `scripts/gm-login keychain` reauthenticated api-0
- live `scripts/gm-install-check` passed
- live `scripts/gm-smoke` wrote and queried a MemoryEntry

## Notes
The growth replay still fails on its legacy bearer-only `/Task` path, while GrayMatter transport succeeds with stateful auth. A direct stateful `/Task` attempt then failed on payload schema (`Unexpected value OPEN`), so the remaining growth replay issue is transport/payload integration, not the refreshed GrayMatter session itself.