### PR TITLE
feat(mcp): add credit recovery CTAs

### DIFF
--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -692,11 +692,13 @@ function buildRecoveryResult(error, operation, context) {
   const loginUrl = apiUrl(context.apiBase, process.env.GRAYMATTER_LOGIN_PATH || DEFAULT_LOGIN_PATH);
   const retryable = signal.reason === 'insufficient_credits' || signal.reason === 'missing_auth';
 
+  const recoveryActions = recoveryActionsFor(signal.reason, { buyCreditsUrl, signupUrl, loginUrl });
   const structuredContent = {
     ok: false,
     reason: signal.reason,
     blockedOperation: operation,
     message: signal.message,
+    recoveryActions,
     buyCreditsUrl,
     signupUrl,
     loginUrl,
@@ -708,7 +710,7 @@ function buildRecoveryResult(error, operation, context) {
     content: [
       {
         type: 'text',
-        text: JSON.stringify(structuredContent)
+        text: renderRecoveryText(structuredContent)
       }
     ],
     _meta: {
@@ -717,6 +719,7 @@ function buildRecoveryResult(error, operation, context) {
           reason: signal.reason,
           blockedOperation: operation,
           retryable,
+          actions: recoveryActions,
           urls: { buyCreditsUrl, signupUrl, loginUrl }
         },
         debug: {
@@ -728,6 +731,36 @@ function buildRecoveryResult(error, operation, context) {
       }
     }
   };
+}
+
+function recoveryActionsFor(reason, urls) {
+  switch (reason) {
+    case 'insufficient_credits':
+      return [
+        { id: 'buy_credits', label: 'Buy GrayMatter credits', url: urls.buyCreditsUrl, primary: true },
+        { id: 'create_account', label: 'Create or upgrade an account', url: urls.signupUrl, primary: false },
+        { id: 'sign_in', label: 'Sign in with a funded workspace', url: urls.loginUrl, primary: false }
+      ];
+    case 'missing_auth':
+      return [
+        { id: 'sign_in', label: 'Sign in to GrayMatter', url: urls.loginUrl, primary: true },
+        { id: 'create_account', label: 'Create an account', url: urls.signupUrl, primary: false }
+      ];
+    case 'read_only_auth':
+      return [
+        { id: 'sign_in', label: 'Switch to a write-capable account', url: urls.loginUrl, primary: true },
+        { id: 'buy_credits', label: 'Buy credits for the target workspace', url: urls.buyCreditsUrl, primary: false }
+      ];
+    default:
+      return [{ id: 'sign_in', label: 'Sign in to GrayMatter', url: urls.loginUrl, primary: true }];
+  }
+}
+
+function renderRecoveryText(structuredContent) {
+  const actions = (structuredContent.recoveryActions || [])
+    .map((action) => `${action.label}: ${action.url}`)
+    .join('\n');
+  return `${structuredContent.message}\n\nRecovery actions:\n${actions}`;
 }
 
 function classifyRecoveryReason(error) {

--- a/mcp-server/test/recovery.test.js
+++ b/mcp-server/test/recovery.test.js
@@ -54,6 +54,9 @@ test('memory_query returns structured recovery for insufficient credits', async 
     assert.equal(out.retryable, true);
     assert.match(out.buyCreditsUrl, /^https:\/\//);
     assert.match(out.signupUrl, /^https:\/\//);
+    assert.deepEqual(out.recoveryActions.map((action) => action.id), ['buy_credits', 'create_account', 'sign_in']);
+    assert.equal(out.recoveryActions[0].primary, true);
+    assert.match(body.result.content[0].text, /Buy GrayMatter credits: https:\/\//);
   } finally {
     server.close();
     fakeApi.close();
@@ -81,6 +84,8 @@ test('memory_query returns auth recovery for 401', async () => {
     assert.equal(out.reason, 'missing_auth');
     assert.equal(out.retryable, true);
     assert.match(out.loginUrl, /\/auth\/login$/);
+    assert.deepEqual(out.recoveryActions.map((action) => action.id), ['sign_in', 'create_account']);
+    assert.equal(out.recoveryActions[0].primary, true);
   } finally {
     server.close();
     fakeApi.close();
@@ -104,6 +109,7 @@ test('memory_write returns read-only recovery for 403 write forbidden', async ()
     const out = body.result.structuredContent;
     assert.equal(out.reason, 'read_only_auth');
     assert.equal(out.retryable, false);
+    assert.deepEqual(out.recoveryActions.map((action) => action.id), ['sign_in', 'buy_credits']);
   } finally {
     server.close();
     fakeApi.close();


### PR DESCRIPTION
## Summary
- Add explicit recoveryActions CTAs to GrayMatter MCP structured recovery responses
- Render human-readable recovery text instead of raw JSON for blocked credit/auth flows
- Cover insufficient credits, missing auth, and read-only token recovery actions in MCP tests

## Tests
- node --check mcp-server/index.js
- cd mcp-server && npm test

Closes ValkyrLabs/ValkyrAI#2918
