### PR TITLE
fix(mcp): harden hosted connector auth and CORS

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -26,8 +26,11 @@ The repo-level `.mcp.json` points Codex at `node mcp-server/index.js --stdio`.
 
 | Variable | Required | Default | Description |
 | --- | --- | --- | --- |
-| `VALKYR_AUTH_TOKEN` | Recommended | none | Bearer token from `scripts/gm-login`. Can also be passed per request through `X-Valkyr-Token`. |
+| `VALKYR_AUTH_TOKEN` | Local/private only | none | Bearer token from `scripts/gm-login`. In hosted multi-tenant mode this process-wide fallback is ignored. |
 | `VALKYR_API_BASE` | No | `https://api-0.valkyrlabs.com/v1` | API base to target. Use hosted api-0, a self-hosted api-0, or a local GrayMatter Light ThorAPI instance. |
+| `GRAYMATTER_MCP_MODE` | No | `local-dev` | Deployment mode: `local-dev`, `private-stdio`, `single-tenant`, or `hosted-multi-tenant`. Hosted modes disable wildcard CORS. |
+| `GRAYMATTER_ALLOWED_ORIGINS` | Hosted modes | `GRAYMATTER_WIDGET_DOMAIN` | Comma-separated trusted browser origins allowed to receive CORS credentials in hosted/public modes. |
+| `GRAYMATTER_ALLOW_UNSAFE_HEADER_TOKEN` | No | `false` | Explicit override that allows `X-Valkyr-Token` in hosted modes for private testing only. |
 | `GRAYMATTER_LOGIN_COMMAND` | No | `../scripts/gm-login` | Login helper used to refresh process-scoped auth after api-0 returns `SESSION_EXPIRED`. |
 | `GRAYMATTER_LOGIN_TIMEOUT_MS` | No | `30000` | Maximum time allowed for the autonomous login helper during MCP auth recovery. |
 | `GRAYMATTER_WIDGET_DOMAIN` | No | `https://graymatter.valkyrlabs.com` | Public widget origin advertised in Apps SDK resource metadata for ChatGPT app review. |
@@ -57,6 +60,8 @@ VALKYR_API_BASE=http://localhost:8080 GRAYMATTER_LIGHT_MODE=true npm start
 | `POST` | `/mcp` | Public Apps SDK MCP endpoint for ChatGPT connector setup and app review. |
 | `POST` | `/` | Direct JSON-RPC endpoint for simpler clients and tests. |
 | `GET` | `/health` | Readiness check with configured API base and exposed tools. |
+| `GET` | `/health/auth` | Auth/CORS readiness check showing mode, trusted origins, and token fallback posture. |
+| `GET` | `/security` | Alias for `/health/auth`. |
 
 Stdio mode exposes the same JSON-RPC methods over newline-delimited stdin/stdout and does not print startup text to stdout.
 
@@ -95,11 +100,17 @@ When `sourceChannel` is not provided, the server derives it from the strongest a
 
 ## Connect to Claude.ai
 
-1. Run the server somewhere Claude.ai can reach it.
-2. In Claude.ai, add an MCP server integration using `https://your-host/sse`.
-3. Add header `X-Valkyr-Token: <your-token>`.
+For public or shared deployments, use a hosted session/OAuth handoff or short-lived connector bootstrap flow that sends standard bearer auth for the current user. Run hosted connectors with explicit origins, for example:
 
-For local testing, expose port `3333` with a tunnel and use the tunnel URL plus `/sse`.
+```bash
+GRAYMATTER_MCP_MODE=hosted-multi-tenant \
+GRAYMATTER_ALLOWED_ORIGINS=https://claude.ai,https://chatgpt.com \
+npm start
+```
+
+Then add the MCP server integration using `https://your-host/sse`.
+
+For local/private testing only, expose port `3333` with a tunnel and use the tunnel URL plus `/sse`; raw `X-Valkyr-Token` headers are treated as a debug path, not the public happy path.
 
 ```bash
 npm start &
@@ -124,21 +135,24 @@ Add an HTTP MCP server entry that points at the message endpoint:
 
 ## Per-Request Auth
 
-For multi-tenant deployments, do not set a shared `VALKYR_AUTH_TOKEN`. Pass each user's token through `X-Valkyr-Token` so all api-0 calls stay scoped to that user's RBAC permissions.
+For hosted multi-tenant deployments, do not set or depend on a shared `VALKYR_AUTH_TOKEN`; the server ignores process-wide auth in `hosted-multi-tenant` mode. Pass each user's credential as standard `Authorization: Bearer <token>` from the approved session/bootstrap flow so api-0 calls stay scoped to that user's RBAC permissions.
 
-When the server is using process-scoped auth from `VALKYR_AUTH_TOKEN`, `VALKYR_JWT_SESSION`, or the plugin launch environment, a `401 SESSION_EXPIRED` response triggers one autonomous `gm-login env` refresh and retries the original request with the new token. Per-request `X-Valkyr-Token` or bearer credentials are never replaced by process credentials, so tenant-scoped calls remain isolated.
+`X-Valkyr-Token` remains available for `local-dev` and `private-stdio` workflows. Hosted modes reject it unless `GRAYMATTER_ALLOW_UNSAFE_HEADER_TOKEN=true` is deliberately enabled for private testing.
+
+When the server is using process-scoped auth from `VALKYR_AUTH_TOKEN`, `VALKYR_JWT_SESSION`, or the plugin launch environment, a `401 SESSION_EXPIRED` response triggers one autonomous `gm-login env` refresh and retries the original request with the new token. Per-request bearer credentials are never replaced by process credentials, so tenant-scoped calls remain isolated.
 
 ## Production Notes
 
-Railway, Fly.io, and Docker deployments all work as long as the server can reach `VALKYR_API_BASE` and callers provide auth through either `VALKYR_AUTH_TOKEN` or `X-Valkyr-Token`.
+Railway, Fly.io, and Docker deployments all work as long as the server can reach `VALKYR_API_BASE`. Public deployments should run in `single-tenant` or `hosted-multi-tenant` mode with `GRAYMATTER_ALLOWED_ORIGINS` set; token-bearing routes will not emit `access-control-allow-origin: *` in those modes.
 
 For ChatGPT app submission:
 
-1. Deploy this server on a public HTTPS domain.
+1. Deploy this server on a public HTTPS domain with `GRAYMATTER_MCP_MODE=hosted-multi-tenant` and explicit trusted origins.
 2. Submit the connector URL as `https://your-host/mcp`.
 3. Set `GRAYMATTER_WIDGET_DOMAIN` to the public origin that hosts the widget surface.
-4. Provide the GrayMatter privacy policy URL, screenshots, test prompts, and reviewer test credentials through the OpenAI Platform Dashboard only.
-5. Do not commit reviewer passwords, tokens, OAuth secrets, or MFA recovery material.
+4. Verify `/health/auth` reports no wildcard CORS, no hosted `X-Valkyr-Token` happy path, and no multi-tenant process-token fallback.
+5. Provide the GrayMatter privacy policy URL, screenshots, test prompts, and reviewer test credentials through the OpenAI Platform Dashboard only.
+6. Do not commit reviewer passwords, tokens, OAuth secrets, or MFA recovery material.
 
 Minimal Dockerfile:
 

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -19,6 +19,8 @@ const APP_SECURITY_SCHEMES = [
   { type: 'apiKey', in: 'header', name: 'X-Valkyr-Token' },
   { type: 'http', scheme: 'bearer' }
 ];
+const LOCAL_DEPLOYMENT_MODES = new Set(['local-dev', 'private-stdio']);
+const HOSTED_DEPLOYMENT_MODES = new Set(['single-tenant', 'hosted-multi-tenant']);
 
 const tools = [
   defineTool({
@@ -187,7 +189,11 @@ function createGrayMatterMcpServer(options = {}) {
   const fetchImpl = options.fetch || globalThis.fetch;
   const loginProvider = options.loginProvider || runLoginCommand;
   const loginCommand = options.loginCommand || process.env.GRAYMATTER_LOGIN_COMMAND || path.join(__dirname, '..', 'scripts', 'gm-login');
+  const deploymentMode = normalizeDeploymentMode(options.deploymentMode || process.env.GRAYMATTER_MCP_MODE || 'local-dev');
+  const allowedOrigins = parseAllowedOrigins(options.allowedOrigins || process.env.GRAYMATTER_ALLOWED_ORIGINS || widgetDomain);
+  const allowUnsafeHeaderToken = parseBoolean(options.allowUnsafeHeaderToken ?? process.env.GRAYMATTER_ALLOW_UNSAFE_HEADER_TOKEN);
   const processToken = options.token || process.env.VALKYR_AUTH_TOKEN || process.env.VALKYR_JWT_SESSION || '';
+  const security = { deploymentMode, allowedOrigins, allowUnsafeHeaderToken };
 
   if (typeof fetchImpl !== 'function') {
     throw new Error('Global fetch is required. Use Node 20 or newer.');
@@ -198,21 +204,26 @@ function createGrayMatterMcpServer(options = {}) {
       const requestUrl = new URL(req.url, 'http://127.0.0.1');
 
       if (req.method === 'OPTIONS') {
-        sendNoContent(res);
+        sendNoContent(req, res, security);
         return;
       }
 
       if (req.method === 'GET' && requestUrl.pathname === '/health') {
-        sendJson(res, 200, {
+        sendJson(req, res, 200, {
           ok: true,
           apiBase,
           tools: tools.map((tool) => tool.name)
-        });
+        }, security);
+        return;
+      }
+
+      if (req.method === 'GET' && (requestUrl.pathname === '/security' || requestUrl.pathname === '/health/auth')) {
+        sendJson(req, res, 200, authReadiness(security, Boolean(processToken)), security);
         return;
       }
 
       if (req.method === 'GET' && requestUrl.pathname === '/sse') {
-        openSseStream(req, res);
+        openSseStream(req, res, security);
         return;
       }
 
@@ -221,24 +232,25 @@ function createGrayMatterMcpServer(options = {}) {
         const rpcResponse = await handleRpc(rpcRequest, {
           apiBase,
           fetchImpl,
-          ...authContextFrom(req, processToken),
+          ...authContextFrom(req, processToken, security),
           loginCommand,
           loginProvider,
           widgetDomain
         });
 
         if (rpcResponse === null) {
-          sendNoContent(res);
+          sendNoContent(req, res, security);
           return;
         }
 
-        sendJson(res, 200, rpcResponse);
+        sendJson(req, res, 200, rpcResponse, security);
         return;
       }
 
-      sendJson(res, 404, { error: 'Not found' });
+      sendJson(req, res, 404, { error: 'Not found' }, security);
     } catch (error) {
-      sendJson(res, 500, { error: error.message });
+      const status = error && error.statusCode ? error.statusCode : 500;
+      sendJson(req, res, status, { error: error.message }, security);
     }
   });
 }
@@ -935,8 +947,13 @@ function summarizeOpenApi(spec) {
   };
 }
 
-function authContextFrom(req, processToken = '') {
+function authContextFrom(req, processToken = '', security = defaultSecurityConfig()) {
   const headerToken = req.headers['x-valkyr-token'];
+  if (headerToken && HOSTED_DEPLOYMENT_MODES.has(security.deploymentMode) && !security.allowUnsafeHeaderToken) {
+    const error = new Error('X-Valkyr-Token is disabled in hosted GrayMatter MCP mode. Use bearer/session auth or enable the explicit unsafe override for private testing.');
+    error.statusCode = 401;
+    throw error;
+  }
   if (Array.isArray(headerToken)) {
     return { token: headerToken[0] || '', requestScopedToken: Boolean(headerToken[0]) };
   }
@@ -952,6 +969,10 @@ function authContextFrom(req, processToken = '') {
     return { token: bearerMatch[1].trim(), requestScopedToken: true };
   }
 
+  if (security.deploymentMode === 'hosted-multi-tenant') {
+    return { token: '', requestScopedToken: false };
+  }
+
   return { token: processToken || process.env.VALKYR_AUTH_TOKEN || process.env.VALKYR_JWT_SESSION || '', requestScopedToken: false };
 }
 
@@ -961,9 +982,9 @@ function apiUrl(apiBase, endpoint) {
   return new URL(cleanEndpoint, base).toString();
 }
 
-function openSseStream(req, res) {
+function openSseStream(req, res, security = defaultSecurityConfig()) {
   res.writeHead(200, {
-    'access-control-allow-origin': '*',
+    ...corsHeaders(req, security),
     'cache-control': 'no-cache, no-transform',
     connection: 'keep-alive',
     'content-type': 'text/event-stream'
@@ -996,23 +1017,69 @@ function readJson(req) {
   });
 }
 
-function sendJson(res, status, payload) {
+function sendJson(req, res, status, payload, security = defaultSecurityConfig()) {
   res.writeHead(status, {
-    'access-control-allow-origin': '*',
-    'access-control-allow-headers': 'authorization,content-type,x-valkyr-token',
-    'access-control-allow-methods': 'GET,POST,OPTIONS',
+    ...corsHeaders(req, security),
     'content-type': 'application/json'
   });
   res.end(JSON.stringify(payload));
 }
 
-function sendNoContent(res) {
-  res.writeHead(204, {
-    'access-control-allow-origin': '*',
-    'access-control-allow-headers': 'authorization,content-type,x-valkyr-token',
-    'access-control-allow-methods': 'GET,POST,OPTIONS'
-  });
+function sendNoContent(req, res, security = defaultSecurityConfig()) {
+  res.writeHead(204, corsHeaders(req, security));
   res.end();
+}
+
+function defaultSecurityConfig() {
+  return { deploymentMode: 'local-dev', allowedOrigins: [], allowUnsafeHeaderToken: false };
+}
+
+function normalizeDeploymentMode(value) {
+  const mode = String(value || 'local-dev').trim();
+  if (LOCAL_DEPLOYMENT_MODES.has(mode) || HOSTED_DEPLOYMENT_MODES.has(mode)) {
+    return mode;
+  }
+  throw new Error(`Unsupported GrayMatter MCP deployment mode: ${mode}`);
+}
+
+function parseAllowedOrigins(value) {
+  const raw = Array.isArray(value) ? value : String(value || '').split(',');
+  return raw.map((origin) => withoutTrailingSlash(String(origin).trim())).filter(Boolean);
+}
+
+function parseBoolean(value) {
+  return ['1', 'true', 'yes', 'on'].includes(String(value || '').toLowerCase());
+}
+
+function corsHeaders(req, security = defaultSecurityConfig()) {
+  const headers = {
+    'access-control-allow-headers': 'authorization,content-type,x-valkyr-token',
+    'access-control-allow-methods': 'GET,POST,OPTIONS',
+    vary: 'Origin'
+  };
+
+  if (!HOSTED_DEPLOYMENT_MODES.has(security.deploymentMode)) {
+    headers['access-control-allow-origin'] = '*';
+    return headers;
+  }
+
+  const origin = withoutTrailingSlash(Array.isArray(req.headers.origin) ? req.headers.origin[0] : req.headers.origin || '');
+  if (origin && security.allowedOrigins.includes(origin)) {
+    headers['access-control-allow-origin'] = origin;
+  }
+  return headers;
+}
+
+function authReadiness(security, hasProcessToken) {
+  return {
+    ok: true,
+    deploymentMode: security.deploymentMode,
+    hostedMode: HOSTED_DEPLOYMENT_MODES.has(security.deploymentMode),
+    allowedOrigins: security.allowedOrigins,
+    xValkyrTokenAccepted: !HOSTED_DEPLOYMENT_MODES.has(security.deploymentMode) || security.allowUnsafeHeaderToken,
+    processTokenAccepted: security.deploymentMode !== 'hosted-multi-tenant',
+    processTokenConfigured: hasProcessToken
+  };
 }
 
 function toolResult(value) {

--- a/mcp-server/test/server.test.js
+++ b/mcp-server/test/server.test.js
@@ -757,3 +757,109 @@ test('tool errors return JSON-RPC errors instead of HTTP failures', async () => 
     server.close();
   }
 });
+
+test('hosted mode restricts CORS to configured connector origins', async () => {
+  const server = createGrayMatterMcpServer({
+    apiBase: 'https://api-0.example.test/v1',
+    deploymentMode: 'hosted-multi-tenant',
+    allowedOrigins: ['https://chatgpt.com', 'https://graymatter.example.test']
+  });
+  const baseUrl = await listen(server);
+
+  try {
+    const allowed = await fetch(`${baseUrl}/health/auth`, {
+      headers: { origin: 'https://chatgpt.com' }
+    });
+    const allowedBody = await allowed.json();
+    assert.equal(allowed.headers.get('access-control-allow-origin'), 'https://chatgpt.com');
+    assert.equal(allowedBody.deploymentMode, 'hosted-multi-tenant');
+    assert.equal(allowedBody.xValkyrTokenAccepted, false);
+    assert.equal(allowedBody.processTokenAccepted, false);
+
+    const denied = await fetch(`${baseUrl}/health/auth`, {
+      headers: { origin: 'https://evil.example.test' }
+    });
+    assert.equal(denied.status, 200);
+    assert.equal(denied.headers.get('access-control-allow-origin'), null);
+  } finally {
+    server.close();
+  }
+});
+
+test('hosted mode rejects X-Valkyr-Token while preserving bearer auth', async () => {
+  const fakeApi = createFakeApi(async (_req, res, record) => {
+    assert.equal(record.headers.authorization, 'Bearer hosted-bearer');
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ id: 'mem-hosted' }));
+  });
+
+  const apiBase = await listen(fakeApi.server);
+  const server = createGrayMatterMcpServer({
+    apiBase: `${apiBase}/v1`,
+    deploymentMode: 'hosted-multi-tenant',
+    allowedOrigins: ['https://chatgpt.com'],
+    token: 'process-token-must-not-be-used'
+  });
+  const baseUrl = await listen(server);
+
+  try {
+    const rejected = await postRpc(baseUrl, {
+      jsonrpc: '2.0',
+      id: 'unsafe-header-token',
+      method: 'tools/call',
+      params: { name: 'memory_read', arguments: { id: 'mem-hosted' } }
+    }, { 'X-Valkyr-Token': 'raw-header-token', origin: 'https://chatgpt.com' }, '/mcp');
+
+    assert.equal(rejected.status, 401);
+    assert.match(rejected.body.error, /X-Valkyr-Token is disabled/);
+    assert.equal(rejected.body.error.includes('raw-header-token'), false);
+    assert.equal(fakeApi.requests.length, 0);
+
+    const accepted = await postRpc(baseUrl, {
+      jsonrpc: '2.0',
+      id: 'bearer-hosted',
+      method: 'tools/call',
+      params: { name: 'memory_read', arguments: { id: 'mem-hosted' } }
+    }, { authorization: 'Bearer hosted-bearer', origin: 'https://chatgpt.com' }, '/mcp');
+
+    assert.equal(accepted.status, 200);
+    assert.equal(accepted.body.result.content[0].text, JSON.stringify({ id: 'mem-hosted' }));
+    assert.equal(fakeApi.requests.length, 1);
+  } finally {
+    server.close();
+    fakeApi.server.close();
+  }
+});
+
+test('hosted multi-tenant mode does not fall back to a process-wide token', async () => {
+  const fakeApi = createFakeApi(async (_req, res, record) => {
+    assert.equal(record.headers.authorization, undefined);
+    res.writeHead(401, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ message: 'missing auth' }));
+  });
+
+  const apiBase = await listen(fakeApi.server);
+  const server = createGrayMatterMcpServer({
+    apiBase: `${apiBase}/v1`,
+    deploymentMode: 'hosted-multi-tenant',
+    allowedOrigins: ['https://chatgpt.com'],
+    token: 'shared-process-token'
+  });
+  const baseUrl = await listen(server);
+
+  try {
+    const result = await postRpc(baseUrl, {
+      jsonrpc: '2.0',
+      id: 'no-process-token',
+      method: 'tools/call',
+      params: { name: 'memory_read', arguments: { id: 'mem-hosted' } }
+    }, { origin: 'https://chatgpt.com' }, '/mcp');
+
+    assert.equal(result.status, 200);
+    assert.equal(result.body.result.structuredContent.reason, 'missing_auth');
+    assert.equal(fakeApi.requests.length, 1);
+  } finally {
+    server.close();
+    fakeApi.server.close();
+  }
+});


### PR DESCRIPTION
## Summary
- add explicit GrayMatter MCP deployment modes and hosted CORS origin allowlisting
- reject raw X-Valkyr-Token in hosted modes unless an unsafe override is explicitly enabled
- ignore process-wide auth fallback in hosted multi-tenant mode and expose /health/auth readiness
- update connector docs to lead with hosted session/bearer auth posture

## Tests
- npm test -- --test-reporter=spec
- git diff --check

Refs ValkyrLabs/ValkyrAI#2866