### PR TITLE
feat: add attributed GrayMatter credit recovery

### DIFF
--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -9,8 +9,8 @@ const { URL } = require('node:url');
 
 const DEFAULT_API_BASE = 'https://api-0.valkyrlabs.com/v1';
 const DEFAULT_WIDGET_DOMAIN = 'https://graymatter.valkyrlabs.com';
-const DEFAULT_BUY_CREDITS_URL = 'https://valkyrlabs.com/buy-credits';
-const DEFAULT_SIGNUP_URL = 'https://valkyrlabs.com/funnel/white-paper';
+const DEFAULT_BUY_CREDITS_URL = 'https://valkyrlabs.com/graymatter/credits';
+const DEFAULT_SIGNUP_URL = 'https://valkyrlabs.com/graymatter/activate';
 const DEFAULT_LOGIN_PATH = '/auth/login';
 const DEFAULT_PORT = 3333;
 const APP_UI_RESOURCE_URI = 'ui://graymatter/overview.html';
@@ -781,10 +781,23 @@ function buildRecoveryResult(error, operation, context) {
     return null;
   }
 
-  const buyCreditsUrl = process.env.VALKYR_BUY_CREDITS_URL || DEFAULT_BUY_CREDITS_URL;
-  const signupUrl = process.env.VALKYR_HUMAN_SIGNUP_URL || DEFAULT_SIGNUP_URL;
+  const recoveryDetails = extractRecoveryDetails(error.payload);
+  const buyCreditsUrl = recoveryUrl(process.env.VALKYR_BUY_CREDITS_URL || DEFAULT_BUY_CREDITS_URL, {
+    intent: 'recharge',
+    operation,
+    endpoint: error.endpoint,
+    ...recoveryDetails
+  });
+  const signupUrl = recoveryUrl(process.env.VALKYR_HUMAN_SIGNUP_URL || DEFAULT_SIGNUP_URL, {
+    intent: signal.reason === 'starter_credits_missing' ? 'starter_credit_repair' : 'signup',
+    operation,
+    endpoint: error.endpoint,
+    ...recoveryDetails
+  });
   const loginUrl = apiUrl(context.apiBase, process.env.GRAYMATTER_LOGIN_PATH || DEFAULT_LOGIN_PATH);
-  const retryable = signal.reason === 'insufficient_credits' || signal.reason === 'missing_auth';
+  const retryable = signal.reason === 'insufficient_credits'
+    || signal.reason === 'starter_credits_missing'
+    || signal.reason === 'missing_auth';
 
   const recoveryActions = recoveryActionsFor(signal.reason, { buyCreditsUrl, signupUrl, loginUrl });
   const structuredContent = {
@@ -796,6 +809,11 @@ function buildRecoveryResult(error, operation, context) {
     buyCreditsUrl,
     signupUrl,
     loginUrl,
+    requiredCredits: recoveryDetails.requiredCredits,
+    currentBalance: recoveryDetails.currentBalance,
+    traceId: recoveryDetails.traceId,
+    accountId: recoveryDetails.accountId,
+    workspaceId: recoveryDetails.workspaceId,
     retryable
   };
 
@@ -813,6 +831,11 @@ function buildRecoveryResult(error, operation, context) {
           reason: signal.reason,
           blockedOperation: operation,
           retryable,
+          requiredCredits: recoveryDetails.requiredCredits,
+          currentBalance: recoveryDetails.currentBalance,
+          traceId: recoveryDetails.traceId,
+          accountId: recoveryDetails.accountId,
+          workspaceId: recoveryDetails.workspaceId,
           actions: recoveryActions,
           urls: { buyCreditsUrl, signupUrl, loginUrl }
         },
@@ -835,6 +858,12 @@ function recoveryActionsFor(reason, urls) {
         { id: 'create_account', label: 'Create or upgrade an account', url: urls.signupUrl, primary: false },
         { id: 'sign_in', label: 'Sign in with a funded workspace', url: urls.loginUrl, primary: false }
       ];
+    case 'starter_credits_missing':
+      return [
+        { id: 'repair_starter_credits', label: 'Repair missing starter credits', url: urls.signupUrl, primary: true },
+        { id: 'buy_credits', label: 'Buy GrayMatter credits', url: urls.buyCreditsUrl, primary: false },
+        { id: 'sign_in', label: 'Sign in with a funded workspace', url: urls.loginUrl, primary: false }
+      ];
     case 'missing_auth':
       return [
         { id: 'sign_in', label: 'Sign in to GrayMatter', url: urls.loginUrl, primary: true },
@@ -854,7 +883,13 @@ function renderRecoveryText(structuredContent) {
   const actions = (structuredContent.recoveryActions || [])
     .map((action) => `${action.label}: ${action.url}`)
     .join('\n');
-  return `${structuredContent.message}\n\nRecovery actions:\n${actions}`;
+  const details = [
+    structuredContent.requiredCredits ? `Required credits: ${structuredContent.requiredCredits}` : '',
+    structuredContent.currentBalance ? `Current balance: ${structuredContent.currentBalance}` : '',
+    structuredContent.traceId ? `Trace ID: ${structuredContent.traceId}` : ''
+  ].filter(Boolean).join('\n');
+  const detailsBlock = details ? `\n\n${details}` : '';
+  return `${structuredContent.message}${detailsBlock}\n\nRecovery actions:\n${actions}`;
 }
 
 function classifyRecoveryReason(error) {
@@ -864,6 +899,12 @@ function classifyRecoveryReason(error) {
   const lowerText = bodyText.toLowerCase();
 
   if (error.status === 402 || upperText.includes('INSUFFICIENT_FUNDS') || lowerText.includes('insufficient') && lowerText.includes('credit')) {
+    if (starterCreditsMissing(payload, lowerText)) {
+      return {
+        reason: 'starter_credits_missing',
+        message: 'GrayMatter starter credits are missing for this workspace. Repair the starter grant or fund the workspace, then retry.'
+      };
+    }
     return {
       reason: 'insufficient_credits',
       message: 'GrayMatter needs credits before this operation can continue. Buy credits or sign up, then retry.'
@@ -891,6 +932,81 @@ function classifyRecoveryReason(error) {
   }
 
   return null;
+}
+
+function extractRecoveryDetails(payload) {
+  return {
+    requiredCredits: firstPayloadValue(payload, ['requiredCredits'], ['required_credits'], ['required'], ['details', 'requiredCredits']),
+    currentBalance: firstPayloadValue(payload, ['currentBalance'], ['balance'], ['details', 'currentBalance']),
+    traceId: firstPayloadValue(payload, ['traceId'], ['trace_id'], ['details', 'traceId']),
+    accountId: firstPayloadValue(payload, ['accountId'], ['account_id'], ['details', 'accountId']),
+    workspaceId: firstPayloadValue(payload, ['workspaceId'], ['workspace_id'], ['organizationId'], ['orgId'], ['details', 'workspaceId'])
+  };
+}
+
+function firstPayloadValue(payload, ...paths) {
+  if (!payload || typeof payload !== 'object') {
+    return undefined;
+  }
+
+  for (const pathParts of paths) {
+    let cursor = payload;
+    for (const part of pathParts) {
+      if (!cursor || typeof cursor !== 'object' || !Object.prototype.hasOwnProperty.call(cursor, part)) {
+        cursor = undefined;
+        break;
+      }
+      cursor = cursor[part];
+    }
+    if (cursor !== undefined && cursor !== null && cursor !== '') {
+      return String(cursor);
+    }
+  }
+
+  return undefined;
+}
+
+function starterCreditsMissing(payload, lowerText) {
+  const explicit = firstPayloadValue(
+    payload,
+    ['starterCreditsMissing'],
+    ['starter_credits_missing'],
+    ['details', 'starterCreditsMissing'],
+    ['details', 'starter_credits_missing']
+  );
+  if (explicit && explicit !== 'false') {
+    return true;
+  }
+  return lowerText.includes('starter') && lowerText.includes('credit') && (lowerText.includes('missing') || lowerText.includes('grant'));
+}
+
+function recoveryUrl(baseUrl, details) {
+  let url;
+  try {
+    url = new URL(baseUrl);
+  } catch {
+    return baseUrl;
+  }
+
+  const params = {
+    source: 'graymatter',
+    intent: details.intent,
+    operation: details.operation,
+    request_path: details.endpoint,
+    required_credits: details.requiredCredits,
+    current_balance: details.currentBalance,
+    trace_id: details.traceId,
+    account_id: details.accountId,
+    workspace_id: details.workspaceId
+  };
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== null && value !== '') {
+      url.searchParams.set(key, String(value));
+    }
+  }
+
+  return url.toString();
 }
 
 function buildMemoryWritePayload(args) {

--- a/mcp-server/test/recovery.test.js
+++ b/mcp-server/test/recovery.test.js
@@ -35,7 +35,15 @@ async function postRpc(baseUrl, payload) {
 }
 
 test('memory_query returns structured recovery for insufficient credits', async () => {
-  const fakeApi = createFakeApi(402, { code: 'INSUFFICIENT_FUNDS', message: 'insufficient credits' });
+  const fakeApi = createFakeApi(402, {
+    code: 'INSUFFICIENT_FUNDS',
+    message: 'insufficient credits',
+    requiredCredits: 50,
+    currentBalance: '0.00',
+    traceId: 'trace-402',
+    accountId: 'acct-1',
+    workspaceId: 'workspace-1'
+  });
   const apiBase = await listen(fakeApi);
   const server = createGrayMatterMcpServer({ apiBase: `${apiBase}/v1` });
   const baseUrl = await listen(server);
@@ -52,11 +60,65 @@ test('memory_query returns structured recovery for insufficient credits', async 
     assert.equal(out.reason, 'insufficient_credits');
     assert.equal(out.blockedOperation, 'memory_query');
     assert.equal(out.retryable, true);
-    assert.match(out.buyCreditsUrl, /^https:\/\//);
-    assert.match(out.signupUrl, /^https:\/\//);
+    assert.equal(out.requiredCredits, '50');
+    assert.equal(out.currentBalance, '0.00');
+    assert.equal(out.traceId, 'trace-402');
+    assert.equal(out.accountId, 'acct-1');
+    assert.equal(out.workspaceId, 'workspace-1');
+    assert.match(out.buyCreditsUrl, /^https:\/\/valkyrlabs\.com\/graymatter\/credits\?/);
+    assert.match(out.buyCreditsUrl, /intent=recharge/);
+    assert.match(out.buyCreditsUrl, /operation=memory_query/);
+    assert.match(out.buyCreditsUrl, /request_path=MemoryEntry%2Fquery/);
+    assert.match(out.buyCreditsUrl, /required_credits=50/);
+    assert.match(out.buyCreditsUrl, /current_balance=0\.00/);
+    assert.match(out.buyCreditsUrl, /trace_id=trace-402/);
+    assert.match(out.buyCreditsUrl, /workspace_id=workspace-1/);
+    assert.match(out.signupUrl, /^https:\/\/valkyrlabs\.com\/graymatter\/activate\?/);
+    assert.match(out.signupUrl, /intent=signup/);
     assert.deepEqual(out.recoveryActions.map((action) => action.id), ['buy_credits', 'create_account', 'sign_in']);
     assert.equal(out.recoveryActions[0].primary, true);
     assert.match(body.result.content[0].text, /Buy GrayMatter credits: https:\/\//);
+    assert.match(body.result.content[0].text, /Required credits: 50/);
+    assert.equal(body.result._meta.openai.recovery.requiredCredits, '50');
+    assert.equal(body.result._meta.openai.recovery.traceId, 'trace-402');
+  } finally {
+    server.close();
+    fakeApi.close();
+  }
+});
+
+test('memory_query returns starter-credit repair recovery when signup grant is missing', async () => {
+  const fakeApi = createFakeApi(402, {
+    code: 'INSUFFICIENT_FUNDS',
+    message: 'starter credit grant missing',
+    starterCreditsMissing: true,
+    currentBalance: '0.00',
+    traceId: 'starter-trace',
+    workspaceId: 'workspace-new'
+  });
+  const apiBase = await listen(fakeApi);
+  const server = createGrayMatterMcpServer({ apiBase: `${apiBase}/v1` });
+  const baseUrl = await listen(server);
+
+  try {
+    const body = await postRpc(baseUrl, {
+      jsonrpc: '2.0',
+      id: 'starter-credit',
+      method: 'tools/call',
+      params: { name: 'memory_query', arguments: { query: 'hello' } }
+    });
+
+    const out = body.result.structuredContent;
+    assert.equal(out.reason, 'starter_credits_missing');
+    assert.equal(out.retryable, true);
+    assert.equal(out.currentBalance, '0.00');
+    assert.equal(out.traceId, 'starter-trace');
+    assert.deepEqual(out.recoveryActions.map((action) => action.id), ['repair_starter_credits', 'buy_credits', 'sign_in']);
+    assert.equal(out.recoveryActions[0].primary, true);
+    assert.match(out.recoveryActions[0].url, /intent=starter_credit_repair/);
+    assert.match(out.recoveryActions[0].url, /workspace_id=workspace-new/);
+    assert.match(body.result.content[0].text, /Repair missing starter credits: https:\/\//);
+    assert.equal(body.result._meta.openai.recovery.reason, 'starter_credits_missing');
   } finally {
     server.close();
     fakeApi.close();


### PR DESCRIPTION
## Summary
- Add attributed GrayMatter MCP recovery URLs for credit-gated operations.
- Surface required credits, current balance, trace, account, and workspace metadata in structured tool responses and Apps SDK meta.
- Add a distinct starter-credit repair recovery path when the upstream payload indicates the signup grant is missing.

Related ValkyrAI issue: ValkyrLabs/ValkyrAI#2870

## Verification
- node --test test/recovery.test.js
- bash tests/mcp_contract_test.sh
- bash tests/mcp_portable_contract_test.sh

Note: bash tests/graymatter_api_test.sh still fails on existing token-refresh ordering assertion: "graymatter_api should call login before the original endpoint when the stored JWT is already expired".