### PR TITLE
fix: route GrayMatter recovery to activation funnel (#2946)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -172,8 +172,8 @@ Design boundary:
 ## Account signup and credits
 
 For a new GrayMatter account, use:
-- Signup: <https://api-0.valkyrlabs.com/v1/auth/signup>
-- Credits and recharge: <https://api-0.valkyrlabs.com/v1/credits>
+- Signup and activation: <https://valkyrlabs.com/graymatter/activate?source=graymatter&intent=signup&operation=memory_query>
+- Credits and recharge: <https://valkyrlabs.com/graymatter/credits?source=graymatter&intent=recharge&operation=memory_query>
 
 Commercial model:
 - fresh signups should receive **500 starter credits** automatically
@@ -401,10 +401,8 @@ Known operational note:
 - `/MemoryEntry/query` may require credits even when write/read paths succeed
 - new signups should receive an automatic 500-credit grant so GrayMatter query works immediately during activation
 - after starter credits are exhausted, recharge is required for full GrayMatter functionality
-- signup: <https://api-0.valkyrlabs.com/v1/auth/signup>
-- credits and recharge: <https://api-0.valkyrlabs.com/v1/credits>
-- buy credits: <https://valkyrlabs.com/buy-credits>
-- human signup form: <https://valkyrlabs.com/funnel/white-paper>
+- signup and activation: <https://valkyrlabs.com/graymatter/activate?source=graymatter&intent=signup&operation=memory_query>
+- credits and recharge: <https://valkyrlabs.com/graymatter/credits?source=graymatter&intent=recharge&operation=memory_query>
 - `scripts/graymatter_api.sh` prints both links on `INSUFFICIENT_FUNDS` and attempts a popup prompt on macOS/Windows
 - optional overrides: `VALKYR_BUY_CREDITS_URL`, `VALKYR_HUMAN_SIGNUP_URL`
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -194,4 +194,4 @@ CMD ["node", "index.js"]
 
 ## Credits
 
-Some hosted GrayMatter operations, notably `memory_query` and receipt-backed retrieval/evaluation lanes, consume api-0 credits. Fresh signups should receive 500 starter credits automatically. Recharge at <https://valkyrlabs.com/buy-credits>.
+Some hosted GrayMatter operations, notably `memory_query` and receipt-backed retrieval/evaluation lanes, consume api-0 credits. Fresh signups should receive 500 starter credits automatically. Recharge at <https://valkyrlabs.com/graymatter/credits?source=graymatter&intent=recharge&operation=memory_query>, or activate a new workspace at <https://valkyrlabs.com/graymatter/activate?source=graymatter&intent=signup&operation=memory_query>.

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -9,8 +9,8 @@ const { URL } = require('node:url');
 
 const DEFAULT_API_BASE = 'https://api-0.valkyrlabs.com/v1';
 const DEFAULT_WIDGET_DOMAIN = 'https://graymatter.valkyrlabs.com';
-const DEFAULT_BUY_CREDITS_URL = 'https://valkyrlabs.com/buy-credits';
-const DEFAULT_SIGNUP_URL = 'https://valkyrlabs.com/funnel/white-paper';
+const DEFAULT_BUY_CREDITS_URL = 'https://valkyrlabs.com/graymatter/credits';
+const DEFAULT_SIGNUP_URL = 'https://valkyrlabs.com/graymatter/activate';
 const DEFAULT_LOGIN_PATH = '/auth/login';
 const DEFAULT_PORT = 3333;
 const APP_UI_RESOURCE_URI = 'ui://graymatter/overview.html';
@@ -943,8 +943,18 @@ function buildRecoveryResult(error, operation, context) {
     return null;
   }
 
-  const buyCreditsUrl = process.env.VALKYR_BUY_CREDITS_URL || DEFAULT_BUY_CREDITS_URL;
-  const signupUrl = process.env.VALKYR_HUMAN_SIGNUP_URL || DEFAULT_SIGNUP_URL;
+  const buyCreditsUrl = activationContextUrl(
+    process.env.VALKYR_BUY_CREDITS_URL || DEFAULT_BUY_CREDITS_URL,
+    'recharge',
+    operation,
+    context
+  );
+  const signupUrl = activationContextUrl(
+    process.env.VALKYR_HUMAN_SIGNUP_URL || DEFAULT_SIGNUP_URL,
+    'signup',
+    operation,
+    context
+  );
   const loginUrl = apiUrl(context.apiBase, process.env.GRAYMATTER_LOGIN_PATH || DEFAULT_LOGIN_PATH);
   const retryable = signal.reason === 'insufficient_credits' || signal.reason === 'missing_auth';
 
@@ -987,6 +997,30 @@ function buildRecoveryResult(error, operation, context) {
       }
     }
   };
+}
+
+function activationContextUrl(baseUrl, intent, operation, context = {}) {
+  const url = new URL(baseUrl);
+  const params = {
+    source: process.env.GRAYMATTER_ACTIVATION_SOURCE || 'graymatter',
+    intent,
+    operation: operation || 'memory_query',
+    return_to: process.env.GRAYMATTER_ACTIVATION_RETURN_TO || 'graymatter://activation/return',
+    api_base: context.apiBase || DEFAULT_API_BASE
+  };
+
+  const installId = process.env.GRAYMATTER_INSTALL_ID || process.env.OPENCLAW_INSTANCE_ID || '';
+  if (installId) {
+    params.install_id = installId;
+  }
+
+  for (const [key, value] of Object.entries(params)) {
+    if (!url.searchParams.has(key) && value) {
+      url.searchParams.set(key, value);
+    }
+  }
+
+  return url.toString();
 }
 
 function recoveryActionsFor(reason, urls) {

--- a/mcp-server/test/recovery.test.js
+++ b/mcp-server/test/recovery.test.js
@@ -34,33 +34,71 @@ async function postRpc(baseUrl, payload) {
   return response.json();
 }
 
-test('memory_query returns structured recovery for insufficient credits', async () => {
-  const fakeApi = createFakeApi(402, { code: 'INSUFFICIENT_FUNDS', message: 'insufficient credits' });
-  const apiBase = await listen(fakeApi);
-  const server = createGrayMatterMcpServer({ apiBase: `${apiBase}/v1` });
-  const baseUrl = await listen(server);
+async function withActivationEnv(env, fn) {
+  const previous = {};
+  for (const key of Object.keys(env)) {
+    previous[key] = process.env[key];
+    if (env[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = env[key];
+    }
+  }
 
   try {
-    const body = await postRpc(baseUrl, {
-      jsonrpc: '2.0',
-      id: 'credit',
-      method: 'tools/call',
-      params: { name: 'memory_query', arguments: { query: 'hello' } }
-    });
-
-    const out = body.result.structuredContent;
-    assert.equal(out.reason, 'insufficient_credits');
-    assert.equal(out.blockedOperation, 'memory_query');
-    assert.equal(out.retryable, true);
-    assert.match(out.buyCreditsUrl, /^https:\/\//);
-    assert.match(out.signupUrl, /^https:\/\//);
-    assert.deepEqual(out.recoveryActions.map((action) => action.id), ['buy_credits', 'create_account', 'sign_in']);
-    assert.equal(out.recoveryActions[0].primary, true);
-    assert.match(body.result.content[0].text, /Buy GrayMatter credits: https:\/\//);
+    return await fn();
   } finally {
-    server.close();
-    fakeApi.close();
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
   }
+}
+
+test('memory_query returns structured recovery for insufficient credits', async () => {
+  await withActivationEnv({
+    VALKYR_BUY_CREDITS_URL: undefined,
+    VALKYR_HUMAN_SIGNUP_URL: undefined,
+    GRAYMATTER_ACTIVATION_SOURCE: undefined,
+    GRAYMATTER_INSTALL_ID: 'install-123'
+  }, async () => {
+    const fakeApi = createFakeApi(402, { code: 'INSUFFICIENT_FUNDS', message: 'insufficient credits' });
+    const apiBase = await listen(fakeApi);
+    const server = createGrayMatterMcpServer({ apiBase: `${apiBase}/v1` });
+    const baseUrl = await listen(server);
+
+    try {
+      const body = await postRpc(baseUrl, {
+        jsonrpc: '2.0',
+        id: 'credit',
+        method: 'tools/call',
+        params: { name: 'memory_query', arguments: { query: 'hello' } }
+      });
+
+      const out = body.result.structuredContent;
+      const buyCreditsUrl = new URL(out.buyCreditsUrl);
+      const signupUrl = new URL(out.signupUrl);
+      assert.equal(out.reason, 'insufficient_credits');
+      assert.equal(out.blockedOperation, 'memory_query');
+      assert.equal(out.retryable, true);
+      assert.equal(`${buyCreditsUrl.origin}${buyCreditsUrl.pathname}`, 'https://valkyrlabs.com/graymatter/credits');
+      assert.equal(`${signupUrl.origin}${signupUrl.pathname}`, 'https://valkyrlabs.com/graymatter/activate');
+      assert.equal(buyCreditsUrl.searchParams.get('source'), 'graymatter');
+      assert.equal(buyCreditsUrl.searchParams.get('intent'), 'recharge');
+      assert.equal(buyCreditsUrl.searchParams.get('operation'), 'memory_query');
+      assert.equal(buyCreditsUrl.searchParams.get('install_id'), 'install-123');
+      assert.equal(signupUrl.searchParams.get('intent'), 'signup');
+      assert.deepEqual(out.recoveryActions.map((action) => action.id), ['buy_credits', 'create_account', 'sign_in']);
+      assert.equal(out.recoveryActions[0].primary, true);
+      assert.match(body.result.content[0].text, /Buy GrayMatter credits: https:\/\//);
+    } finally {
+      server.close();
+      fakeApi.close();
+    }
+  });
 });
 
 test('memory_query returns auth recovery for 401', async () => {

--- a/tests/docs_consistency_test.sh
+++ b/tests/docs_consistency_test.sh
@@ -40,10 +40,16 @@ DOC_FILES=(
 old_smoke="gm-light-"'smoke'
 future_sample="future local runnable sample"
 future_service="provide a runnable GrayMatter Light local service"
+raw_api_signup="api-0.valkyrlabs.com/v1/auth/signup"
+generic_buy_credits="valkyrlabs.com/buy-credits"
+generic_white_paper="valkyrlabs.com/funnel/white-paper"
 
 assert_absent "$old_smoke" "${DOC_FILES[@]}"
 assert_absent "$future_sample" "${DOC_FILES[@]}"
 assert_absent "$future_service" "${DOC_FILES[@]}"
+assert_absent "$raw_api_signup" "${DOC_FILES[@]}"
+assert_absent "$generic_buy_credits" "${DOC_FILES[@]}"
+assert_absent "$generic_white_paper" "${DOC_FILES[@]}"
 
 assert_contains "gm-light-json-smoke" "README.md"
 assert_contains "gm-light-json-smoke" "docs/graymatter-light.md"


### PR DESCRIPTION
## Summary
- replace MCP recovery defaults with dedicated GrayMatter activation and recharge routes
- append activation context to MCP recovery URLs so blocked operations can resume after signup/recharge
- update skill/docs consistency checks to reject raw API signup, generic buy-credits, and white-paper recovery links

## Tests
- npm test (mcp-server)
- bash tests/docs_consistency_test.sh

## Note
- bash tests/graymatter_api_test.sh still fails on the existing expired-JWT refresh ordering assertion before this change touched that script.