### PR TITLE
feat: polish GrayMatter credit recovery

### DIFF
--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -944,20 +944,18 @@ function buildRecoveryResult(error, operation, context) {
     return null;
   }
 
-  const buyCreditsUrl = activationContextUrl(
-    process.env.VALKYR_BUY_CREDITS_URL || DEFAULT_BUY_CREDITS_URL,
-    'recharge',
-    operation,
-    context
-  );
-  const signupUrl = activationContextUrl(
-    process.env.VALKYR_HUMAN_SIGNUP_URL || DEFAULT_SIGNUP_URL,
-    'signup',
-    operation,
-    context
-  );
+  const details = recoveryDetails(error.payload);
+  const attribution = recoveryAttribution(error, operation, context, details);
+  const buyCreditsUrl = attributedRecoveryUrl(process.env.VALKYR_BUY_CREDITS_URL || DEFAULT_BUY_CREDITS_URL, {
+    ...attribution,
+    intent: 'recharge'
+  });
+  const signupUrl = attributedRecoveryUrl(process.env.VALKYR_HUMAN_SIGNUP_URL || DEFAULT_SIGNUP_URL, {
+    ...attribution,
+    intent: signal.reason === 'starter_credits_missing' ? 'repair-starter-credits' : 'signup'
+  });
   const loginUrl = apiUrl(context.apiBase, process.env.GRAYMATTER_LOGIN_PATH || DEFAULT_LOGIN_PATH);
-  const retryable = signal.reason === 'insufficient_credits' || signal.reason === 'missing_auth';
+  const retryable = signal.reason === 'insufficient_credits' || signal.reason === 'starter_credits_missing' || signal.reason === 'missing_auth';
 
   const recoveryActions = recoveryActionsFor(signal.reason, { buyCreditsUrl, signupUrl, loginUrl });
   const structuredContent = {
@@ -969,6 +967,12 @@ function buildRecoveryResult(error, operation, context) {
     buyCreditsUrl,
     signupUrl,
     loginUrl,
+    currentBalance: details.currentBalance,
+    requiredCredits: details.requiredCredits,
+    traceId: details.traceId,
+    workspaceId: details.workspaceId,
+    accountId: details.accountId,
+    retryGuidance: retryable ? 'Complete the recovery action, then call this tool again with the same arguments.' : 'Switch credentials or workspace access before retrying.',
     retryable
   };
 
@@ -1026,6 +1030,12 @@ function activationContextUrl(baseUrl, intent, operation, context = {}) {
 
 function recoveryActionsFor(reason, urls) {
   switch (reason) {
+    case 'starter_credits_missing':
+      return [
+        { id: 'repair_starter_credits', label: 'Repair starter credits', url: urls.signupUrl, primary: true },
+        { id: 'buy_credits', label: 'Buy GrayMatter credits', url: urls.buyCreditsUrl, primary: false },
+        { id: 'sign_in', label: 'Sign in with a funded workspace', url: urls.loginUrl, primary: false }
+      ];
     case 'insufficient_credits':
       return [
         { id: 'buy_credits', label: 'Buy GrayMatter credits', url: urls.buyCreditsUrl, primary: true },
@@ -1051,7 +1061,14 @@ function renderRecoveryText(structuredContent) {
   const actions = (structuredContent.recoveryActions || [])
     .map((action) => `${action.label}: ${action.url}`)
     .join('\n');
-  return `${structuredContent.message}\n\nRecovery actions:\n${actions}`;
+  const facts = [
+    structuredContent.currentBalance ? `Current balance: ${structuredContent.currentBalance}` : '',
+    structuredContent.requiredCredits ? `Required credits: ${structuredContent.requiredCredits}` : '',
+    structuredContent.workspaceId ? `Workspace: ${structuredContent.workspaceId}` : '',
+    structuredContent.traceId ? `Trace: ${structuredContent.traceId}` : ''
+  ].filter(Boolean).join('\n');
+  const factBlock = facts ? `\n\n${facts}` : '';
+  return `${structuredContent.message}${factBlock}\n\nRecovery actions:\n${actions}\n\n${structuredContent.retryGuidance}`;
 }
 
 function classifyRecoveryReason(error) {
@@ -1059,6 +1076,13 @@ function classifyRecoveryReason(error) {
   const bodyText = typeof payload === 'string' ? payload : JSON.stringify(payload || {});
   const upperText = bodyText.toUpperCase();
   const lowerText = bodyText.toLowerCase();
+
+  if (upperText.includes('STARTER_CREDITS_MISSING') || lowerText.includes('starter') && lowerText.includes('credit') && lowerText.includes('missing')) {
+    return {
+      reason: 'starter_credits_missing',
+      message: 'This account is missing its expected GrayMatter starter credits. Repair the starter grant or choose a funded workspace, then retry.'
+    };
+  }
 
   if (error.status === 402 || upperText.includes('INSUFFICIENT_FUNDS') || lowerText.includes('insufficient') && lowerText.includes('credit')) {
     return {
@@ -1088,6 +1112,53 @@ function classifyRecoveryReason(error) {
   }
 
   return null;
+}
+
+function recoveryDetails(payload) {
+  const source = payload && typeof payload === 'object' && !Array.isArray(payload) ? payload : {};
+  const details = source.details && typeof source.details === 'object' ? source.details : {};
+  return {
+    currentBalance: firstDefined(source.currentBalance, source.balance, details.currentBalance, details.balance),
+    requiredCredits: firstDefined(source.requiredCredits, source.required_credits, source.required, details.requiredCredits, details.required),
+    traceId: firstDefined(source.traceId, source.trace_id, details.traceId, details.trace_id),
+    workspaceId: firstDefined(source.workspaceId, source.workspace_id, source.organizationId, source.orgId, details.workspaceId, details.organizationId),
+    accountId: firstDefined(source.accountId, source.account_id, source.principalId, details.accountId, details.principalId)
+  };
+}
+
+function recoveryAttribution(error, operation, context, details) {
+  return {
+    source: process.env.GRAYMATTER_ACTIVATION_SOURCE || 'graymatter',
+    operation,
+    request_path: error.endpoint,
+    api_base: context.apiBase,
+    install_id: process.env.GRAYMATTER_INSTALL_ID || process.env.OPENCLAW_INSTANCE_ID || '',
+    return_to: process.env.GRAYMATTER_ACTIVATION_RETURN_TO || 'graymatter://activation/return',
+    required_credits: details.requiredCredits,
+    current_balance: details.currentBalance,
+    trace_id: details.traceId,
+    workspace_id: details.workspaceId,
+    account_id: details.accountId
+  };
+}
+
+function attributedRecoveryUrl(baseUrl, params) {
+  const url = new URL(baseUrl);
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== null && String(value) !== '') {
+      url.searchParams.set(key, String(value));
+    }
+  }
+  return url.toString();
+}
+
+function firstDefined(...values) {
+  for (const value of values) {
+    if (value !== undefined && value !== null && String(value) !== '') {
+      return String(value);
+    }
+  }
+  return undefined;
 }
 
 function buildMemoryWritePayload(args) {

--- a/mcp-server/test/recovery.test.js
+++ b/mcp-server/test/recovery.test.js
@@ -65,7 +65,14 @@ test('memory_query returns structured recovery for insufficient credits', async 
     GRAYMATTER_ACTIVATION_SOURCE: undefined,
     GRAYMATTER_INSTALL_ID: 'install-123'
   }, async () => {
-    const fakeApi = createFakeApi(402, { code: 'INSUFFICIENT_FUNDS', message: 'insufficient credits' });
+    const fakeApi = createFakeApi(402, {
+      code: 'INSUFFICIENT_FUNDS',
+      message: 'insufficient credits',
+      requiredCredits: 25,
+      currentBalance: '0.00',
+      traceId: 'trace-credits',
+      workspaceId: 'workspace-7'
+    });
     const apiBase = await listen(fakeApi);
     const server = createGrayMatterMcpServer({ apiBase: `${apiBase}/v1` });
     const baseUrl = await listen(server);
@@ -84,21 +91,60 @@ test('memory_query returns structured recovery for insufficient credits', async 
       assert.equal(out.reason, 'insufficient_credits');
       assert.equal(out.blockedOperation, 'memory_query');
       assert.equal(out.retryable, true);
+      assert.equal(out.requiredCredits, '25');
+      assert.equal(out.currentBalance, '0.00');
+      assert.equal(out.traceId, 'trace-credits');
+      assert.equal(out.workspaceId, 'workspace-7');
       assert.equal(`${buyCreditsUrl.origin}${buyCreditsUrl.pathname}`, 'https://valkyrlabs.com/graymatter/credits');
       assert.equal(`${signupUrl.origin}${signupUrl.pathname}`, 'https://valkyrlabs.com/graymatter/activate');
       assert.equal(buyCreditsUrl.searchParams.get('source'), 'graymatter');
       assert.equal(buyCreditsUrl.searchParams.get('intent'), 'recharge');
       assert.equal(buyCreditsUrl.searchParams.get('operation'), 'memory_query');
       assert.equal(buyCreditsUrl.searchParams.get('install_id'), 'install-123');
+      assert.equal(buyCreditsUrl.searchParams.get('workspace_id'), 'workspace-7');
       assert.equal(signupUrl.searchParams.get('intent'), 'signup');
       assert.deepEqual(out.recoveryActions.map((action) => action.id), ['buy_credits', 'create_account', 'sign_in']);
       assert.equal(out.recoveryActions[0].primary, true);
       assert.match(body.result.content[0].text, /Buy GrayMatter credits: https:\/\//);
+      assert.match(body.result.content[0].text, /Current balance: 0\.00/);
     } finally {
       server.close();
       fakeApi.close();
     }
   });
+});
+
+test('memory_query distinguishes missing starter credits from paid credit depletion', async () => {
+  const fakeApi = createFakeApi(402, {
+    code: 'STARTER_CREDITS_MISSING',
+    message: 'starter credit grant missing',
+    requiredCredits: 500,
+    currentBalance: '0.00',
+    accountId: 'acct-1'
+  });
+  const apiBase = await listen(fakeApi);
+  const server = createGrayMatterMcpServer({ apiBase: `${apiBase}/v1` });
+  const baseUrl = await listen(server);
+
+  try {
+    const body = await postRpc(baseUrl, {
+      jsonrpc: '2.0',
+      id: 'starter',
+      method: 'tools/call',
+      params: { name: 'memory_query', arguments: { query: 'hello' } }
+    });
+
+    const out = body.result.structuredContent;
+    assert.equal(out.reason, 'starter_credits_missing');
+    assert.equal(out.retryable, true);
+    assert.equal(out.accountId, 'acct-1');
+    assert.deepEqual(out.recoveryActions.map((action) => action.id), ['repair_starter_credits', 'buy_credits', 'sign_in']);
+    assert.match(out.signupUrl, /intent=repair-starter-credits/);
+    assert.match(body.result.content[0].text, /Repair starter credits:/);
+  } finally {
+    server.close();
+    fakeApi.close();
+  }
 });
 
 test('memory_query returns auth recovery for 401', async () => {

--- a/scripts/graymatter_api.sh
+++ b/scripts/graymatter_api.sh
@@ -114,6 +114,15 @@ token_is_clearly_read_only() {
     return $?
   fi
 
+  if printf '%s' "$claims" | grep -Eq '"(ADMIN|USER|OWNER|MANAGER|SUPER_ADMIN|ROLE_[^"]+)"'; then
+    return 1
+  fi
+  if printf '%s' "$claims" | grep -Eq 'SCOPE_[^"]*(write|admin|delete|update|create)'; then
+    return 1
+  fi
+  if printf '%s' "$claims" | grep -Eq '"(EVERYONE|FREE)"|SCOPE_schema\.read'; then
+    return 0
+  fi
   return 1
 }
 
@@ -134,7 +143,10 @@ token_expires_soon() {
     return $?
   fi
 
-  return 1
+  local exp=""
+  exp="$(printf '%s' "$claims" | sed -n 's/.*"exp"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' | head -n 1)"
+  [[ -n "$exp" ]] || return 1
+  [[ "$exp" -le $((now + TOKEN_REFRESH_SKEW_SECONDS)) ]]
 }
 
 method_requires_write_access() {
@@ -322,6 +334,9 @@ show_insufficient_funds_guidance() {
   buy_credits_url="$(append_query_param "$buy_credits_url" current_balance "$current_balance")"
   buy_credits_url="$(append_query_param "$buy_credits_url" trace_id "$trace_id")"
 
+  echo "GrayMatter credit recovery" >&2
+  echo "Account/workspace: install=${GRAYMATTER_INSTALL_ID} api=${BASE}" >&2
+  echo "Blocked operation: ${operation_kind}" >&2
   echo "Insufficient credits. Buy credits: ${buy_credits_url}" >&2
   echo "Need an account? Sign up here: ${human_signup_url}" >&2
   if [[ -n "$required_credits" ]]; then

--- a/tests/graymatter_api_test.sh
+++ b/tests/graymatter_api_test.sh
@@ -455,6 +455,8 @@ test_insufficient_funds_shows_links_and_uses_macos_prompt() {
   output="$(printf '%s\n' "${result}" | tail -n +2)"
 
   [[ "${status}" == "22" ]] || fail "graymatter_api should return 22 for HTTP errors"
+  assert_contains "${output}" "GrayMatter credit recovery" "graymatter_api should render a branded credit recovery header"
+  assert_contains "${output}" "Blocked operation: memory_read" "graymatter_api should show the blocked operation"
   assert_contains "${output}" "Insufficient credits. Buy credits: https://example.com/buy" "graymatter_api should print buy-credits guidance"
   assert_contains "${output}" "Need an account? Sign up here: https://example.com/signup" "graymatter_api should print signup guidance"
   assert_contains "${output}" "source=graymatter" "graymatter_api should preserve source attribution in activation links"


### PR DESCRIPTION
## Summary
- add attributed GrayMatter credit recovery URLs for MCP insufficient-funds responses
- distinguish missing starter-credit grants from normal paid credit depletion
- render CLI credit recovery context and add jq-free JWT fallback checks

## Tests
- npm test --prefix mcp-server
- bash tests/graymatter_api_test.sh

Tracks ValkyrLabs/ValkyrAI#2870