### PR TITLE
test: cover GrayMatter stateful XSRF writes

### DIFF
--- a/tests/graymatter_api_test.sh
+++ b/tests/graymatter_api_test.sh
@@ -43,6 +43,7 @@ set -euo pipefail
 
 out_file=""
 headers_file=""
+cookie_jar=""
 all_args="$*"
 if [[ -n "${TEST_CURL_LOG:-}" ]]; then
   printf '%s\n' "$all_args" >>"${TEST_CURL_LOG}"
@@ -55,6 +56,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     -D)
       headers_file="$2"
+      shift 2
+      ;;
+    -c)
+      cookie_jar="$2"
       shift 2
       ;;
     *)
@@ -132,6 +137,48 @@ case "${TEST_CURL_SCENARIO:-success}" in
       printf '200'
     fi
     ;;
+  write-requires-xsrf)
+    if [[ "$all_args" == *"/auth/login"* ]]; then
+      printf '{"%s":"%s"}\n' token stateful-token >"${out_file}"
+      if [[ -n "$headers_file" ]]; then
+        printf 'HTTP/1.1 200 OK\nSet-Cookie: VALKYR_AUTH=stateful-token; Path=/; HttpOnly\nSet-Cookie: XSRF-TOKEN=stateful-xsrf; Path=/\n' >"${headers_file}"
+      fi
+      if [[ -n "$cookie_jar" ]]; then
+        {
+          printf '# Netscape HTTP Cookie File\n'
+          printf 'api-0.valkyrlabs.com\tFALSE\t/\tFALSE\t0\tVALKYR_AUTH\tstateful-token\n'
+          printf 'api-0.valkyrlabs.com\tFALSE\t/\tFALSE\t0\tXSRF-TOKEN\tstateful-xsrf\n'
+        } >"${cookie_jar}"
+      fi
+      printf '200'
+    elif [[ "$all_args" == *"-X POST"* && "$all_args" == *"/MemoryEntry"* ]]; then
+      if [[ "$all_args" != *"X-XSRF-TOKEN: stateful-xsrf"* ]]; then
+        printf '{"error":"MISSING_XSRF"}\n' >"${out_file}"
+        if [[ -n "$headers_file" ]]; then
+          printf 'HTTP/1.1 403 Forbidden\n' >"${headers_file}"
+        fi
+        printf '403'
+      elif [[ "$all_args" != *" -b "* ]]; then
+        printf '{"error":"MISSING_COOKIE_JAR"}\n' >"${out_file}"
+        if [[ -n "$headers_file" ]]; then
+          printf 'HTTP/1.1 403 Forbidden\n' >"${headers_file}"
+        fi
+        printf '403'
+      else
+        printf '{"ok":true,"stateful":true}\n' >"${out_file}"
+        if [[ -n "$headers_file" ]]; then
+          printf 'HTTP/1.1 200 OK\n' >"${headers_file}"
+        fi
+        printf '200'
+      fi
+    else
+      printf '{"ok":true}\n' >"${out_file}"
+      if [[ -n "$headers_file" ]]; then
+        printf 'HTTP/1.1 200 OK\n' >"${headers_file}"
+      fi
+      printf '200'
+    fi
+    ;;
   transport-fail)
     echo "curl transport failure" >&2
     exit 7
@@ -182,11 +229,10 @@ case "$cmd" in
       exit 1
     fi
 
-    if [[ "${TEST_SECURITY_SCENARIO:-}" == "missing-token" ]]; then
-      exit 44
-    fi
-
     if [[ "$service" == "VALKYR_AUTH" && "$account" == "valor" ]]; then
+      if [[ "${TEST_SECURITY_SCENARIO:-}" == "missing-token" ]]; then
+        exit 44
+      fi
       if [[ "${TEST_SECURITY_SCENARIO:-}" == "readonly-token" ]]; then
         printf 'eyJhbGciOiJub25lIn0.eyJyb2xlcyI6WyJFVkVSWU9ORSJdLCJzY29wZXMiOlsiU0NPUEVfc2NoZW1hLnJlYWQiXSwidXNlcm5hbWUiOiJ2YWxvciJ9.\n'
       elif [[ "${TEST_SECURITY_SCENARIO:-}" == "expired-jwt-token" ]]; then
@@ -208,6 +254,9 @@ case "$cmd" in
     fi
 
     if [[ "$service" == "VALKYR_AUTH" && "$account" == "default" ]]; then
+      if [[ "${TEST_SECURITY_SCENARIO:-}" == "missing-token" ]]; then
+        exit 44
+      fi
       if [[ "${TEST_SECURITY_SCENARIO:-}" == "readonly-token" ]]; then
         printf 'eyJhbGciOiJub25lIn0.eyJyb2xlcyI6WyJFVkVSWU9ORSJdLCJzY29wZXMiOlsiU0NPUEVfc2NoZW1hLnJlYWQiXSwidXNlcm5hbWUiOiJ2YWxvciJ9.\n'
       elif [[ "${TEST_SECURITY_SCENARIO:-}" == "expired-jwt-token" ]]; then
@@ -459,7 +508,7 @@ test_insufficient_funds_write_creates_deferred_replay_record() {
 
   set +e
   result="$(
-    PATH="${fake_bin}:/usr/bin:/bin" \
+    PATH="${fake_bin}:/usr/local/bin:/usr/bin:/bin" \
     TMPDIR="${temp_root}" \
     VALKYR_AUTH_TOKEN=test-token \
     "${script_copy}" POST /MemoryEntry '{"type":"context","text":"hello"}' 2>&1
@@ -495,7 +544,7 @@ test_insufficient_funds_urls_do_not_leak_token_or_memory_body() {
 
   set +e
   result="$(
-    PATH="${fake_bin}:/usr/bin:/bin" \
+    PATH="${fake_bin}:/usr/local/bin:/usr/bin:/bin" \
     TMPDIR="${temp_root}" \
     "${script_copy}" POST /MemoryEntry "{\"type\":\"context\",\"text\":\"${secret_body}\"}" 2>&1
   )"
@@ -530,7 +579,7 @@ test_unauthorized_refreshes_token_from_keychain_credentials() {
   local output
 
   result="$(
-    PATH="${fake_bin}:/usr/bin:/bin" \
+    PATH="${fake_bin}:/usr/local/bin:/usr/bin:/bin" \
     TMPDIR="${temp_root}" \
     "${script_copy}" GET /MemoryEntry/stats 2>&1
   )"
@@ -565,7 +614,7 @@ test_missing_token_runs_login_before_request() {
   local output
 
   result="$(
-    PATH="${fake_bin}:/usr/bin:/bin" \
+    PATH="${fake_bin}:/usr/local/bin:/usr/bin:/bin" \
     TMPDIR="${temp_root}" \
     "${script_copy}" GET /MemoryEntry/stats 2>&1
   )"
@@ -595,7 +644,7 @@ test_expired_keychain_token_refreshes_before_original_request() {
   local output
 
   result="$(
-    PATH="${fake_bin}:/usr/bin:/bin" \
+    PATH="${fake_bin}:/usr/local/bin:/usr/bin:/bin" \
     TMPDIR="${temp_root}" \
     "${script_copy}" GET /MemoryEntry/stats 2>&1
   )"
@@ -617,7 +666,7 @@ test_curl_requests_use_default_timeouts() {
 
   export TEST_CURL_SCENARIO="success"
 
-  PATH="${fake_bin}:/usr/bin:/bin" \
+  PATH="${fake_bin}:/usr/local/bin:/usr/bin:/bin" \
   TMPDIR="${temp_root}" \
   VALKYR_AUTH_TOKEN=test-token \
   "${script_copy}" GET /MemoryEntry/stats >/dev/null 2>&1
@@ -640,7 +689,7 @@ test_success_uses_fallback_tempdir_when_default_tmp_fails() {
   local output
 
   result="$(
-    PATH="${fake_bin}:/usr/bin:/bin" \
+    PATH="${fake_bin}:/usr/local/bin:/usr/bin:/bin" \
     TMPDIR="/blocked-tmp" \
     VALKYR_AUTH_TOKEN=test-token \
     "${script_copy}" GET /MemoryEntry/stats 2>&1
@@ -682,7 +731,7 @@ test_write_rejects_read_only_token_before_network_request() {
 
   set +e
   result="$(
-    PATH="${fake_bin}:/usr/bin:/bin" \
+    PATH="${fake_bin}:/usr/local/bin:/usr/bin:/bin" \
     TMPDIR="${temp_root}" \
     "${script_copy}" POST /MemoryEntry '{"type":"context","text":"x"}' 2>&1
   )"
@@ -722,7 +771,7 @@ test_light_mode_allows_local_request_without_token() {
 
   set +e
   result="$(
-    PATH="${fake_bin}:/usr/bin:/bin" \
+    PATH="${fake_bin}:/usr/local/bin:/usr/bin:/bin" \
     TMPDIR="${temp_root}" \
     GRAYMATTER_LIGHT_MODE=true \
     VALKYR_API_BASE="http://localhost:8899" \
@@ -736,6 +785,36 @@ test_light_mode_allows_local_request_without_token() {
   assert_file_missing "${temp_root}/gm-login.log" "graymatter_api should not run hosted login in light mode"
 }
 
+test_write_uses_stateful_cookie_and_xsrf_after_login() {
+  local temp_root="$1"
+  local fake_bin="$2"
+  local script_copy="$3"
+
+  export TEST_CURL_SCENARIO="write-requires-xsrf"
+  export TEST_SECURITY_SCENARIO="missing-token"
+  unset VALKYR_AUTH_TOKEN
+  unset GRAYMATTER_USERNAME
+  unset GRAYMATTER_PASSWORD
+  unset VALKYR_USERNAME
+  unset VALKYR_PASSWORD
+
+  local result
+  local status=0
+
+  set +e
+  result="$(
+    PATH="${fake_bin}:/usr/local/bin:/usr/bin:/bin" \
+    TMPDIR="${temp_root}" \
+    "${script_copy}" POST /MemoryEntry '{"type":"context","text":"stateful write"}' 2>&1
+  )"
+  status=$?
+  set -e
+
+  [[ "${status}" == "0" ]] || fail "graymatter_api should satisfy stateful XSRF-protected writes after login"
+  assert_contains "${result}" '{"ok":true,"stateful":true}' "graymatter_api should retry the write with cookie jar and XSRF header"
+  assert_contains "$(cat "${temp_root}/curl.log")" "/auth/login" "graymatter_api should establish a stateful login before hosted writes"
+}
+
 with_fixture test_success_passthrough
 with_fixture test_insufficient_funds_shows_links_and_uses_macos_prompt
 with_fixture test_insufficient_funds_falls_back_to_windows_prompt
@@ -744,6 +823,7 @@ with_fixture test_missing_token_runs_login_before_request
 with_fixture test_expired_keychain_token_refreshes_before_original_request
 with_fixture test_curl_requests_use_default_timeouts
 with_fixture test_success_uses_fallback_tempdir_when_default_tmp_fails
+with_fixture test_write_uses_stateful_cookie_and_xsrf_after_login
 test_write_rejects_read_only_token_before_network_request
 test_light_mode_allows_local_request_without_token
 


### PR DESCRIPTION
## Summary
- add a GrayMatter API regression that requires hosted writes to carry the login cookie jar and X-XSRF-TOKEN header
- make the fake curl fixture write a Netscape cookie jar for stateful login scenarios
- keep the test harness able to find jq on macOS Homebrew paths

## Context
Fallback unblocker for ValkyrAI issue #3002: GrayMatter mutating requests previously failed unless they used stateful cookie/XSRF auth.

## Verification
- tests/graymatter_api_test.sh

Related: ValkyrLabs/ValkyrAI#3002