### PR TITLE
fix: fail fast on degraded gm-write auth

### DIFF
--- a/scripts/gm-write
+++ b/scripts/gm-write
@@ -89,6 +89,44 @@ done
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+queue_fallback() {
+  local reason="$1"
+  local chars="${#TEXT}"
+  if [[ -x "${SCRIPT_DIR}/gm-fallback-append" ]]; then
+    "${SCRIPT_DIR}/gm-fallback-append" "$TYPE" "$TEXT" "$SOURCE_CHANNEL" "$reason" >/dev/null 2>&1 || true
+    echo "Write failed, queued fallback payload in memory/graymatter-fallback.json (chars=${chars})" >&2
+  fi
+}
+
+preflight_write_state() {
+  [[ "${GRAYMATTER_GM_WRITE_PREFLIGHT:-true}" == "false" ]] && return 0
+  [[ -x "${SCRIPT_DIR}/gm-status" ]] || return 0
+
+  local status_output=""
+  status_output="$(GM_STATUS_FORMAT=kv "${SCRIPT_DIR}/gm-status" 2>/dev/null)" || return 0
+
+  local auth_state=""
+  local token_state=""
+  local memory_layer=""
+  auth_state="$(awk -F= '$1 == "graymatter_auth" {print $2; exit}' <<<"$status_output")"
+  token_state="$(awk -F= '$1 == "graymatter_token_state" {print $2; exit}' <<<"$status_output")"
+  memory_layer="$(awk -F= '$1 == "memory_layer" {print $2; exit}' <<<"$status_output")"
+
+  if [[ "$auth_state" == *":read_only"* || "$token_state" == "read_only" ]]; then
+    echo "gm-write cannot write with read-only GrayMatter auth (auth=${auth_state:-unknown}, token=${token_state:-unknown})." >&2
+    echo "Use a write-capable VALKYR_AUTH token or run scripts/gm-login with an account that can write MemoryEntry." >&2
+    queue_fallback "gm-write preflight blocked read-only auth"
+    exit 23
+  fi
+
+  if [[ -n "$memory_layer" && "$memory_layer" != "ready" ]]; then
+    echo "gm-write cannot write while GrayMatter memory_layer=${memory_layer}." >&2
+    echo "Run scripts/gm-status and scripts/gm-doctor --quick, then retry or replay with scripts/gm-replay-deferred." >&2
+    queue_fallback "gm-write preflight blocked memory_layer=${memory_layer}"
+    exit 24
+  fi
+}
+
 derive_scope_from_path() {
   local path="$1"
   if [[ "$path" =~ \.codex/automations/([^/]+) ]]; then
@@ -195,6 +233,8 @@ else
   PAYLOAD="$(jq -nc --arg type "$TYPE" --arg text "$TEXT" --arg sourceChannel "$SOURCE_CHANNEL" '{type:$type,text:$text,source:$sourceChannel}')"
 fi
 
+preflight_write_state
+
 set +e
 RESPONSE="$(${SCRIPT_DIR}/graymatter_api.sh POST /MemoryEntry/write "$PAYLOAD" 2>&1)"
 STATUS=$?
@@ -221,10 +261,7 @@ if [[ $STATUS -ne 0 ]]; then
   echo "gm-write failed (type=${TYPE}, sourceChannel=${SOURCE_CHANNEL}, chars=${TEXT_LEN}, exit=${STATUS})." >&2
 fi
 
-if [[ -x "${SCRIPT_DIR}/gm-fallback-append" ]]; then
-  "${SCRIPT_DIR}/gm-fallback-append" "$TYPE" "$TEXT" "$SOURCE_CHANNEL" "gm-write API failure (chars=${TEXT_LEN})" >/dev/null 2>&1 || true
-  echo "Write failed, queued fallback payload in memory/graymatter-fallback.json (chars=${TEXT_LEN})" >&2
-fi
+queue_fallback "gm-write API failure (chars=${TEXT_LEN})"
 
 printf '%s\n' "$RESPONSE" >&2
 exit $STATUS

--- a/tests/gm_write_test.sh
+++ b/tests/gm_write_test.sh
@@ -8,6 +8,13 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 cp "$ROOT_DIR/scripts/gm-write" "$TMP_DIR/gm-write"
 chmod +x "$TMP_DIR/gm-write"
 
+cat > "$TMP_DIR/gm-fallback-append" <<'EOF'
+#!/usr/bin/env bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+printf '%s|%s|%s|%s\n' "$1" "$2" "$3" "$4" >> "$SCRIPT_DIR/gm-fallback-calls"
+EOF
+chmod +x "$TMP_DIR/gm-fallback-append"
+
 cat > "$TMP_DIR/graymatter_api.sh" <<'EOF'
 #!/usr/bin/env bash
 echo "HTTP 413 Payload Too Large" >&2
@@ -19,5 +26,51 @@ OUTPUT="$($TMP_DIR/gm-write todo "$(printf 'x%.0s' {1..1200})" test 2>&1 || true
 
 grep -q "gm-write rejected payload length" <<<"$OUTPUT"
 grep -q "gm-write failed (type=todo, sourceChannel=test" <<<"$OUTPUT"
+
+cat > "$TMP_DIR/gm-status" <<'EOF'
+#!/usr/bin/env bash
+cat <<STATUS
+graymatter_auth=keychain:read_only
+graymatter_token_state=ok
+memory_layer=degraded
+graph_layer=missing
+strategic_layer=missing
+kpi_layer=missing
+STATUS
+EOF
+chmod +x "$TMP_DIR/gm-status"
+
+rm -f "$TMP_DIR/gm-fallback-calls"
+set +e
+READ_ONLY_OUTPUT="$($TMP_DIR/gm-write context "signal sweep payload" signal-harvester signal,github 2>&1)"
+READ_ONLY_STATUS=$?
+set -e
+
+test "$READ_ONLY_STATUS" -eq 23
+grep -q "read-only GrayMatter auth" <<<"$READ_ONLY_OUTPUT"
+grep -q "queued fallback payload" <<<"$READ_ONLY_OUTPUT"
+grep -q "gm-write preflight blocked read-only auth" "$TMP_DIR/gm-fallback-calls"
+
+cat > "$TMP_DIR/gm-status" <<'EOF'
+#!/usr/bin/env bash
+cat <<STATUS
+graymatter_auth=keychain:write_capable
+graymatter_token_state=ok
+memory_layer=degraded
+graph_layer=missing
+strategic_layer=missing
+kpi_layer=missing
+STATUS
+EOF
+
+rm -f "$TMP_DIR/gm-fallback-calls"
+set +e
+DEGRADED_OUTPUT="$($TMP_DIR/gm-write artifact "operator payload" signal-harvester signal 2>&1)"
+DEGRADED_STATUS=$?
+set -e
+
+test "$DEGRADED_STATUS" -eq 24
+grep -q "memory_layer=degraded" <<<"$DEGRADED_OUTPUT"
+grep -q "gm-write preflight blocked memory_layer=degraded" "$TMP_DIR/gm-fallback-calls"
 
 echo "gm_write_test: PASS"


### PR DESCRIPTION
## Summary
- add a gm-write preflight that reads gm-status before mutating MemoryEntry writes
- fail fast for read-only auth or degraded memory_layer with clear recovery guidance
- queue the fallback payload with a precise preflight reason so operators can replay later

## Validation
- tests/gm_write_test.sh
- tests/gm_status_test.sh
- git diff --check

## Note
- tests/graymatter_api_test.sh still fails on the existing expired-JWT login sequencing assertion: "graymatter_api should call login before the original endpoint when the stored JWT is already expired". This PR does not change graymatter_api.sh.

Related: ValkyrLabs/ValkyrAI#2818