### PR TITLE
fix: reject stale GrayMatter install auth

### DIFF
--- a/scripts/gm-install-check
+++ b/scripts/gm-install-check
@@ -148,6 +148,27 @@ token_health_state() {
   ' <<<"$claims"
 }
 
+token_live_state() {
+  local token="${1:-}"
+  local code=""
+
+  [[ -n "$token" ]] || {
+    printf 'missing\n'
+    return 0
+  }
+
+  code="$(curl -sS -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 10 \
+    -H "Authorization: Bearer $token" \
+    -H 'accept: application/json' \
+    "${BASE%/}/auth/me" 2>/dev/null || true)"
+
+  case "$code" in
+    2*) printf 'valid\n' ;;
+    401|403) printf 'invalid\n' ;;
+    *) printf 'unknown\n' ;;
+  esac
+}
+
 run_login() {
   local login_cmd="${GRAYMATTER_LOGIN_COMMAND:-${SCRIPT_DIR}/gm-login}"
   if [[ ! -x "$login_cmd" ]]; then
@@ -214,6 +235,17 @@ case "$TOKEN_STATE" in
     ;;
 esac
 pass "GrayMatter auth token health: ${TOKEN_STATE}"
+
+TOKEN_LIVE_STATE="$(token_live_state "$TOKEN")"
+case "$TOKEN_LIVE_STATE" in
+  invalid)
+    if run_login && [[ -n "$TOKEN" ]]; then
+      TOKEN_LIVE_STATE="$(token_live_state "$TOKEN")"
+    fi
+    [[ "$TOKEN_LIVE_STATE" != "invalid" ]] || fail "GrayMatter auth token is stale or replaced according to ${BASE%/}/auth/me, and automatic re-login did not refresh it."
+    ;;
+esac
+pass "GrayMatter auth live state: ${TOKEN_LIVE_STATE}"
 
 if curl --silent --show-error --fail --max-time 10 "$BASE" >/dev/null 2>&1; then
   pass "API base reachable: $BASE"

--- a/tests/gm_install_check_test.sh
+++ b/tests/gm_install_check_test.sh
@@ -48,6 +48,23 @@ EOF
   cat >"${dir}/curl" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+all_args="$*"
+if [[ "$all_args" == *"/auth/me"* ]]; then
+  if [[ "${TEST_CURL_AUTH_ME_SCENARIO:-valid}" == "invalid-once" ]]; then
+    state_file="${TEST_CURL_STATE_FILE:?}"
+    count=0
+    if [[ -f "$state_file" ]]; then
+      count="$(cat "$state_file")"
+    fi
+    if [[ "$count" == "0" ]]; then
+      printf '1' >"$state_file"
+      printf '401'
+      exit 0
+    fi
+  fi
+  printf '200'
+  exit 0
+fi
 printf '{}'
 EOF
   chmod +x "${dir}/curl"
@@ -68,12 +85,39 @@ test_install_check_relogs_when_keychain_token_is_read_only() {
   chmod +x "${script_copy}"
   make_fake_bin "${fake_bin}"
 
-  output="$(PATH="${fake_bin}:/usr/bin:/bin" "${script_copy}" 2>&1)"
+  output="$(PATH="${fake_bin}:/usr/local/bin:/usr/bin:/bin" "${script_copy}" 2>&1)"
 
   assert_contains "${output}" "GrayMatter install check passed" "gm-install-check should pass after automatic re-login replaces a read-only token"
   assert_contains "${output}" "GrayMatter auth source detected" "gm-install-check should report auth success after re-login"
 }
 
+test_install_check_relogs_when_keychain_session_is_stale_live() {
+  local temp_root
+  local fake_bin
+  local script_copy
+  local output
+
+  temp_root="$(mktemp -d)"
+  fake_bin="${temp_root}/bin"
+  script_copy="${temp_root}/gm-install-check"
+  mkdir -p "${fake_bin}"
+
+  cp "${SCRIPT_SRC}" "${script_copy}"
+  chmod +x "${script_copy}"
+  make_fake_bin "${fake_bin}"
+
+  output="$(
+    TEST_CURL_AUTH_ME_SCENARIO="invalid-once" \
+    TEST_CURL_STATE_FILE="${temp_root}/curl.state" \
+    PATH="${fake_bin}:/usr/local/bin:/usr/bin:/bin" \
+    "${script_copy}" 2>&1
+  )"
+
+  assert_contains "${output}" "GrayMatter auth live state: valid" "gm-install-check should re-login when auth/me rejects the stored session"
+  assert_contains "${output}" "GrayMatter install check passed" "gm-install-check should pass after replacing a stale live session"
+}
+
 test_install_check_relogs_when_keychain_token_is_read_only
+test_install_check_relogs_when_keychain_session_is_stale_live
 
 printf 'PASS: gm_install_check_test.sh\n'


### PR DESCRIPTION
## Summary
- validates stored GrayMatter auth against live `/auth/me` during install checks
- automatically re-runs `gm-login` when the live session is stale or replaced
- covers the stale live-session path in `gm_install_check_test.sh`

## Validation
- `tests/gm_install_check_test.sh`
- `tests/gm_status_test.sh`
- Attempted `tests/graymatter_api_test.sh`; existing adjacent failure remains: `graymatter_api should call login before the original endpoint when the stored JWT is already expired`

Cross-repo issue: ValkyrLabs/ValkyrAI#2570