### PR TITLE
fix(graymatter): align ClawHub skill release metadata

### DIFF
--- a/clawhub.json
+++ b/clawhub.json
@@ -1,7 +1,7 @@
 {
   "slug": "graymatter",
   "name": "GrayMatter",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "tags": [
     "memory",
     "durable-memory",
@@ -12,5 +12,5 @@
     "valkyr",
     "latest"
   ],
-  "changelog": "GrayMatter-first OpenClaw launch: primary-memory bootstrap, live OpenAPI schema loading, generic entity access helpers, stronger installability guidance, plus signup and credits-link onboarding notes"
+  "changelog": "GrayMatter skill packaging now ships the activation runtime, graymatter-bootstrap recovery path, MCP server, and install validation scripts required for fresh OpenClaw and ClawHub installs."
 }

--- a/tests/release_surfaces_test.sh
+++ b/tests/release_surfaces_test.sh
@@ -17,6 +17,15 @@ require jq -e '.keywords | index("mcp")' "$ROOT/.codex-plugin/plugin.json" >/dev
 require jq -e '.interface.capabilities | index("Interactive")' "$ROOT/.codex-plugin/plugin.json" >/dev/null
 require jq -e '.interface.longDescription | contains("mcp-server")' "$ROOT/.codex-plugin/plugin.json" >/dev/null
 require jq -e '.plugins[] | select(.name == "graymatter") | .source.path == "./plugins/graymatter"' "$ROOT/.agents/plugins/marketplace.json" >/dev/null
+require jq -e '.slug == "graymatter"' "$ROOT/clawhub.json" >/dev/null
+require jq -e '.tags | index("openclaw-skill")' "$ROOT/clawhub.json" >/dev/null
+
+PLUGIN_VERSION="$(jq -r '.version' "$ROOT/.codex-plugin/plugin.json")"
+CLAW_HUB_VERSION="$(jq -r '.version' "$ROOT/clawhub.json")"
+if [[ "$CLAW_HUB_VERSION" != "$PLUGIN_VERSION" ]]; then
+  echo "clawhub.json version must match .codex-plugin/plugin.json (${CLAW_HUB_VERSION} != ${PLUGIN_VERSION})" >&2
+  exit 1
+fi
 
 require jq -e '.mcpServers.graymatter.command == "node"' "$ROOT/.mcp.json" >/dev/null
 require jq -e '.mcpServers.graymatter.args == ["mcp-server/index.js", "--stdio"]' "$ROOT/.mcp.json" >/dev/null
@@ -71,9 +80,15 @@ grep -q '^graymatter/SKILL.md$' "$ZIP_LIST"
 grep -q '^graymatter/skills/graymatter-analytics/SKILL.md$' "$ZIP_LIST"
 grep -q '^graymatter/skills/graymatter-analytics/references/semantic-layer-template.md$' "$ZIP_LIST"
 grep -q '^graymatter/scripts/gm-activate$' "$ZIP_LIST"
+grep -q '^graymatter/scripts/gm-login$' "$ZIP_LIST"
+grep -q '^graymatter/scripts/gm-install-check$' "$ZIP_LIST"
 grep -q '^graymatter/scripts/gm-doctor$' "$ZIP_LIST"
+grep -q '^graymatter/scripts/gm-register-agent$' "$ZIP_LIST"
+grep -q '^graymatter/scripts/gm-openapi-sync$' "$ZIP_LIST"
+grep -q '^graymatter/scripts/gm-openapi-summary$' "$ZIP_LIST"
 grep -q '^graymatter/scripts/gm-light-up$' "$ZIP_LIST"
 grep -q '^graymatter/mcp-server/index.js$' "$ZIP_LIST"
 grep -q '^graymatter/.mcp.json$' "$ZIP_LIST"
+grep -q '^graymatter/graymatter-bootstrap$' "$ZIP_LIST"
 
 echo "release_surfaces_test: ok"


### PR DESCRIPTION
Summary
- Bump clawhub.json to the current 0.2.1 skill/plugin release that contains the activation runtime bundle.
- Add release-surface coverage so ClawHub metadata cannot drift from the plugin version.
- Expand packaged-skill assertions for graymatter-bootstrap, gm-login, gm-install-check, agent registration, and OpenAPI sync scripts.

Verification
- tests/release_surfaces_test.sh
- tests/end_user_install_test.sh
- scripts/package-graymatter

Fixes ValkyrLabs/ValkyrAI#3230