### PR TITLE
feat: add gm-status format flags

### DIFF
--- a/scripts/gm-status
+++ b/scripts/gm-status
@@ -19,6 +19,54 @@ fi
 KEYCHAIN_SERVICE="${VALKYR_KEYCHAIN_SERVICE:-VALKYR_AUTH}"
 API_BASE="${VALKYR_API_BASE:-https://api-0.valkyrlabs.com/v1}"
 API_BASE="${API_BASE%/}"
+GM_STATUS_FORMAT="${GM_STATUS_FORMAT:-kv}"
+
+usage() {
+  cat <<'USAGE'
+Usage: gm-status [--json|--format kv|--format json]
+
+Report GrayMatter auth, tenant schema, fallback queue, and cached schema readiness.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --json)
+      GM_STATUS_FORMAT="json"
+      shift
+      ;;
+    --format)
+      [[ $# -ge 2 ]] || {
+        usage >&2
+        exit 2
+      }
+      GM_STATUS_FORMAT="$2"
+      shift 2
+      ;;
+    --format=*)
+      GM_STATUS_FORMAT="${1#--format=}"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'gm-status: unknown option %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$GM_STATUS_FORMAT" in
+  kv|json) ;;
+  *)
+    printf 'gm-status: unsupported format %s\n' "$GM_STATUS_FORMAT" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
 
 decode_base64_url() {
   local value="${1:-}"
@@ -247,7 +295,7 @@ elif [[ "$AUTH_STATE" == "missing" || "$PENDING_WRITES" != "0" || "$TOKEN_STATE"
   HEALTH="degraded"
 fi
 
-if [[ "${GM_STATUS_FORMAT:-kv}" == "json" ]]; then
+if [[ "$GM_STATUS_FORMAT" == "json" ]]; then
   jq -nc \
     --arg health "$HEALTH" \
     --arg auth "$AUTH_STATE" \

--- a/tests/gm_login_test.sh
+++ b/tests/gm_login_test.sh
@@ -3,6 +3,12 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LOGIN_SRC="${ROOT}/scripts/gm-login"
+REAL_JQ="$(command -v jq || true)"
+[[ -n "${REAL_JQ}" ]] || {
+  printf 'FAIL: jq is required for gm_login_test.sh\n' >&2
+  exit 1
+}
+export TEST_REAL_JQ="${REAL_JQ}"
 
 fail() {
   printf 'FAIL: %s\n' "$1" >&2
@@ -27,7 +33,7 @@ set -euo pipefail
 if [[ "${1:-}" == "-nc" ]]; then
   printf '{"username":"%s","password":"%s"}\n' valor fixture-password
 else
-  /usr/bin/jq "$@"
+  "${TEST_REAL_JQ}" "$@"
 fi
 EOF
   chmod +x "${dir}/jq"

--- a/tests/gm_status_test.sh
+++ b/tests/gm_status_test.sh
@@ -45,4 +45,22 @@ echo "$out_agent" | grep -q '^tenant_schema_name=main$'
 echo "$out_agent" | grep -q '^tenant_schema_source=jwt_valkyr_agent_main_schema_fallback$'
 echo "$out_agent" | grep -q '^memory_layer=degraded$'
 
+json_out="$(ROOT_DIR="$TMP_DIR" VALKYR_API_BASE="http://127.0.0.1:9/v1" VALKYR_AUTH_TOKEN="$valkyr_agent_jwt" "$TMP_DIR/gm-status" --json)"
+jq -e '
+  .graymatter.health == "ok"
+  and .graymatter.auth == "env_token"
+  and .graymatter.tenantSchemaContext.tenantSchemaContext == "ready"
+  and .graymatter.tenantSchemaContext.schemaName == "main"
+  and .graymatter.fallback.pendingWrites == 0
+' <<<"$json_out" >/dev/null
+
+format_json_out="$(ROOT_DIR="$TMP_DIR" VALKYR_API_BASE="http://127.0.0.1:9/v1" VALKYR_AUTH_TOKEN="$valkyr_agent_jwt" "$TMP_DIR/gm-status" --format=json)"
+jq -e '.graymatter.tenantSchemaContext.source == "jwt_valkyr_agent_main_schema_fallback"' <<<"$format_json_out" >/dev/null
+
+if "$TMP_DIR/gm-status" --format yaml >/tmp/gm-status-invalid.out 2>&1; then
+  echo "expected invalid format failure" >&2
+  exit 1
+fi
+grep -q "unsupported format yaml" /tmp/gm-status-invalid.out
+
 echo "gm_status_test: ok"


### PR DESCRIPTION
## Summary
- add explicit gm-status --json and --format kv/json options around the existing status output modes
- reject unsupported formats with usage output for automation-safe failures
- cover JSON flag, --format=json, and invalid format handling in gm_status_test
- make the gm-login test jq shim portable across macOS/Homebrew jq locations so the broader shell suite validates cleanly

## Tests
- tests/gm_status_test.sh
- bash tests/gm_login_test.sh
- for t in tests/*_test.sh; do bash "$t"; done

## Notes
- npm test --prefix mcp-server -- --runInBand was stopped after hanging on an unrelated auth recovery path.
- Full shell-suite run passed with packaging warnings from tar about locale/deprecated compression.