### PR TITLE
fix(graymatter): classify credit-gated memory queries

### DIFF
--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -519,7 +519,9 @@ function createGrayMatterMcpServer(options = {}) {
   const fetchImpl = options.fetch || globalThis.fetch;
   const loginProvider = options.loginProvider || runLoginCommand;
   const loginCommand = options.loginCommand || process.env.GRAYMATTER_LOGIN_COMMAND || path.join(__dirname, '..', 'scripts', 'gm-login');
-  const apiShellProvider = options.apiShellProvider || runShellApiCommand;
+  const apiShellProvider = Object.prototype.hasOwnProperty.call(options, 'apiShellProvider')
+    ? options.apiShellProvider
+    : runShellApiCommand;
   const apiCommand = options.apiCommand || process.env.GRAYMATTER_API_COMMAND || path.join(__dirname, '..', 'scripts', 'graymatter_api.sh');
   const replayCommand = options.replayCommand || process.env.GRAYMATTER_REPLAY_COMMAND || path.join(__dirname, '..', 'scripts', 'gm-replay-deferred');
   const keychainReader = options.keychainReader || readTokenFromKeychain;
@@ -605,7 +607,9 @@ function createRpcContext(options = {}) {
   const fetchImpl = options.fetch || globalThis.fetch;
   const loginProvider = options.loginProvider || runLoginCommand;
   const loginCommand = options.loginCommand || process.env.GRAYMATTER_LOGIN_COMMAND || path.join(__dirname, '..', 'scripts', 'gm-login');
-  const apiShellProvider = options.apiShellProvider || runShellApiCommand;
+  const apiShellProvider = Object.prototype.hasOwnProperty.call(options, 'apiShellProvider')
+    ? options.apiShellProvider
+    : runShellApiCommand;
   const apiCommand = options.apiCommand || process.env.GRAYMATTER_API_COMMAND || path.join(__dirname, '..', 'scripts', 'graymatter_api.sh');
   const replayCommand = options.replayCommand || process.env.GRAYMATTER_REPLAY_COMMAND || path.join(__dirname, '..', 'scripts', 'gm-replay-deferred');
 

--- a/mcp-server/test/recovery.test.js
+++ b/mcp-server/test/recovery.test.js
@@ -10,6 +10,22 @@ async function listen(server) {
   return `http://127.0.0.1:${address.port}`;
 }
 
+async function closeServer(server) {
+  await new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error && error.code !== 'ERR_SERVER_NOT_RUNNING') {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+async function closeServers(...servers) {
+  await Promise.all(servers.map(closeServer));
+}
+
 async function readBody(req) {
   const chunks = [];
   for await (const chunk of req) chunks.push(chunk);
@@ -108,8 +124,7 @@ test('memory_query returns structured recovery for insufficient credits', async 
       assert.match(body.result.content[0].text, /Buy GrayMatter credits: https:\/\//);
       assert.match(body.result.content[0].text, /Current balance: 0\.00/);
     } finally {
-      server.close();
-      fakeApi.close();
+      await closeServers(server, fakeApi);
     }
   });
 });
@@ -142,8 +157,7 @@ test('memory_query distinguishes missing starter credits from paid credit deplet
     assert.match(out.signupUrl, /intent=repair-starter-credits/);
     assert.match(body.result.content[0].text, /Repair starter credits:/);
   } finally {
-    server.close();
-    fakeApi.close();
+    await closeServers(server, fakeApi);
   }
 });
 
@@ -152,7 +166,8 @@ test('memory_query returns auth recovery for 401', async () => {
   const apiBase = await listen(fakeApi);
   const server = createGrayMatterMcpServer({
     apiBase: `${apiBase}/v1`,
-    loginProvider: async () => ''
+    loginProvider: async () => '',
+    apiShellProvider: null
   });
   const baseUrl = await listen(server);
 
@@ -171,15 +186,18 @@ test('memory_query returns auth recovery for 401', async () => {
     assert.deepEqual(out.recoveryActions.map((action) => action.id), ['sign_in', 'create_account']);
     assert.equal(out.recoveryActions[0].primary, true);
   } finally {
-    server.close();
-    fakeApi.close();
+    await closeServers(server, fakeApi);
   }
 });
 
 test('memory_write returns read-only recovery for 403 write forbidden', async () => {
   const fakeApi = createFakeApi(403, { message: 'write forbidden for read-only token' });
   const apiBase = await listen(fakeApi);
-  const server = createGrayMatterMcpServer({ apiBase: `${apiBase}/v1` });
+  const server = createGrayMatterMcpServer({
+    apiBase: `${apiBase}/v1`,
+    loginProvider: async () => '',
+    apiShellProvider: null
+  });
   const baseUrl = await listen(server);
 
   try {
@@ -195,8 +213,7 @@ test('memory_write returns read-only recovery for 403 write forbidden', async ()
     assert.equal(out.retryable, false);
     assert.deepEqual(out.recoveryActions.map((action) => action.id), ['sign_in', 'buy_credits']);
   } finally {
-    server.close();
-    fakeApi.close();
+    await closeServers(server, fakeApi);
   }
 });
 
@@ -217,7 +234,6 @@ test('success path remains plain toolResult content shape', async () => {
     assert.equal(body.result.structuredContent, undefined);
     assert.deepEqual(JSON.parse(body.result.content[0].text), { results: [{ id: 'mem-1' }] });
   } finally {
-    server.close();
-    fakeApi.close();
+    await closeServers(server, fakeApi);
   }
 });

--- a/scripts/graymatter_api.sh
+++ b/scripts/graymatter_api.sh
@@ -575,11 +575,11 @@ show_access_denied_guidance() {
 
 determine_operation_kind() {
   local normalized_path="${PATH_PART#/}"
+  if [[ "$normalized_path" == "MemoryEntry/query"* ]]; then
+    printf 'memory_query\n'
+    return 0
+  fi
   if [[ "$METHOD_UPPER" == "GET" ]]; then
-    if [[ "$normalized_path" == "MemoryEntry/query"* ]]; then
-      printf 'memory_query\n'
-      return 0
-    fi
     printf 'memory_read\n'
     return 0
   fi

--- a/tests/graymatter_api_test.sh
+++ b/tests/graymatter_api_test.sh
@@ -517,6 +517,38 @@ test_insufficient_funds_falls_back_to_windows_prompt() {
 with_fixture test_success_passthrough
 with_fixture test_insufficient_funds_shows_links_and_uses_macos_prompt
 with_fixture test_insufficient_funds_falls_back_to_windows_prompt
+test_insufficient_funds_query_preserves_query_operation() {
+  local temp_root="$1"
+  local fake_bin="$2"
+  local script_copy="$3"
+
+  export TEST_CURL_SCENARIO="insufficient-funds"
+  export TEST_OSASCRIPT_STATUS="0"
+
+  local result
+  local status=0
+  local output
+
+  set +e
+  result="$(
+    PATH="${fake_bin}:/usr/local/bin:/usr/bin:/bin" \
+    TMPDIR="${temp_root}" \
+    VALKYR_AUTH_TOKEN=test-token \
+    "${script_copy}" POST /MemoryEntry/query '{"q":"trustlove","maxResults":5}' 2>&1
+  )"
+  status=$?
+  set -e
+  output="$(printf '%s\n' "${result}")"
+
+  [[ "${status}" == "22" ]] || fail "graymatter_api should return 22 for credit-gated queries"
+  assert_contains "${output}" "Blocked operation: memory_query" "MemoryEntry/query should be classified as a query, not a write"
+  assert_contains "${output}" "operation=memory_query" "Credit recovery URL should preserve the query operation"
+  if [[ -d "${temp_root}/deferred" ]]; then
+    fail "credit-gated memory queries should not create deferred write replay records"
+  fi
+}
+
+with_fixture test_insufficient_funds_query_preserves_query_operation
 test_insufficient_funds_write_creates_deferred_replay_record() {
   local temp_root="$1"
   local fake_bin="$2"


### PR DESCRIPTION
Refs ValkyrLabs/ValkyrAI#2870

## Summary
- classify POST /MemoryEntry/query credit failures as memory_query instead of memory_write
- prevent credit-gated queries from creating deferred write replay records
- make MCP recovery tests close local servers deterministically and allow disabling shell fallback in recovery tests

## Verification
- npm test -- --test-reporter=spec
- bash tests/graymatter_api_test.sh
- bash tests/gm_query_test.sh