### PR TITLE
fix(graymatter): fall back on query quota exhaustion

### DIFF
--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -727,7 +727,7 @@ async function callTool(params, context) {
       return execute('memory_read', () => apiRequest(context, 'GET', `MemoryEntry/${encodeURIComponent(args.id)}`));
     case 'memory_query':
       requireString(args.query, 'query');
-      return execute('memory_query', () => apiRequest(context, 'POST', 'MemoryEntry/query', buildMemoryQueryPayload(args)));
+      return execute('memory_query', () => queryMemoryWithFallback(context, args));
     case 'memory_put_batch':
       return execute('memory_put_batch', async () => {
         if (!Array.isArray(args.items)) {
@@ -1385,6 +1385,106 @@ function buildRecoveryResult(error, operation, context) {
       }
     }
   };
+}
+
+async function queryMemoryWithFallback(context, args) {
+  const payload = buildMemoryQueryPayload(args);
+  try {
+    return await apiRequest(context, 'POST', 'MemoryEntry/query', payload);
+  } catch (error) {
+    if (!isEmbeddingQuotaFailure(error)) {
+      throw error;
+    }
+
+    const entries = await apiRequest(context, 'GET', 'MemoryEntry');
+    const results = lexicalMemoryFallback(entries, {
+      query: args.query,
+      limit: args.limit,
+      type: args.type,
+      source: payload.source
+    });
+
+    return {
+      degraded: true,
+      reason: 'embedding_quota_exhausted',
+      retrievalMode: 'lexical_fallback',
+      query: args.query,
+      count: results.length,
+      warning: 'Semantic memory search is unavailable because the embedding provider quota is exhausted. Results are lexical fallback matches from MemoryEntry list.',
+      action: 'Top up or switch the embedding provider, then retry semantic memory_query.',
+      results
+    };
+  }
+}
+
+function isEmbeddingQuotaFailure(error) {
+  if (!error || error.name !== 'ApiRequestError') {
+    return false;
+  }
+
+  const text = JSON.stringify(error.payload || error.message || '').toLowerCase();
+  return /insufficient_quota|quota exhausted|embedding provider quota|embeddings? failed|openai embeddings failed/.test(text);
+}
+
+function lexicalMemoryFallback(payload, options) {
+  const entries = normalizeMemoryEntries(payload);
+  const query = String(options.query || '').toLowerCase();
+  const terms = Array.from(new Set(query.split(/[^a-z0-9_-]+/u).filter((term) => term.length > 2)));
+  const limit = clampInteger(options.limit, 10, 1, 100);
+  const type = options.type || '';
+  const source = options.source || '';
+
+  return entries
+    .map((entry) => ({ entry, score: lexicalMemoryScore(entry, query, terms) }))
+    .filter(({ entry, score }) => {
+      if (type && entry.type !== type) {
+        return false;
+      }
+      if (source && entry.source !== source && entry.sourceChannel !== source) {
+        return false;
+      }
+      return score > 0;
+    })
+    .sort((left, right) => right.score - left.score)
+    .slice(0, limit)
+    .map(({ entry }) => entry);
+}
+
+function normalizeMemoryEntries(payload) {
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+  if (!payload || typeof payload !== 'object') {
+    return [];
+  }
+  for (const key of ['content', 'items', 'data', 'results', 'records']) {
+    if (Array.isArray(payload[key])) {
+      return payload[key];
+    }
+  }
+  return [];
+}
+
+function lexicalMemoryScore(entry, query, terms) {
+  const haystack = [
+    entry && entry.text,
+    entry && entry.title,
+    entry && entry.summary,
+    entry && entry.description,
+    entry && entry.content,
+    entry && entry.type,
+    Array.isArray(entry && entry.tags)
+      ? entry.tags.map((tag) => typeof tag === 'object' ? (tag.name || tag.id || '') : String(tag)).join(' ')
+      : ''
+  ].filter(Boolean).join(' ').toLowerCase();
+
+  if (!haystack) {
+    return 0;
+  }
+  if (terms.length === 0) {
+    return query && haystack.includes(query) ? 1 : 0;
+  }
+  return terms.reduce((score, term) => score + (haystack.includes(term) ? 1 : 0), 0);
 }
 
 function activationContextUrl(baseUrl, intent, operation, context = {}) {

--- a/mcp-server/test/recovery.test.js
+++ b/mcp-server/test/recovery.test.js
@@ -161,6 +161,71 @@ test('memory_query distinguishes missing starter credits from paid credit deplet
   }
 });
 
+test('memory_query falls back to lexical MemoryEntry list when embeddings quota is exhausted', async () => {
+  const requests = [];
+  const fakeApi = http.createServer(async (req, res) => {
+    const body = await readBody(req);
+    requests.push({ method: req.method, path: new URL(req.url, 'http://fake.local').pathname, body });
+
+    if (req.method === 'POST' && req.url === '/v1/MemoryEntry/query') {
+      res.writeHead(500, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({
+        disabled: true,
+        unavailable: true,
+        error: 'openai embeddings failed: 429 insufficient_quota',
+        warning: 'Memory search is unavailable because the embedding provider quota is exhausted.'
+      }));
+      return;
+    }
+
+    if (req.method === 'GET' && req.url === '/v1/MemoryEntry') {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({
+        content: [
+          { id: 'mem-1', type: 'context', text: 'Stainless sprint CRM warm leads need founder-led follow-up', sourceChannel: 'codex:workspace:crm' },
+          { id: 'mem-2', type: 'todo', text: 'Unrelated billing cleanup', sourceChannel: 'codex:workspace:crm' },
+          { id: 'mem-3', type: 'context', text: 'Stainless pricing objection notes', sourceChannel: 'codex:workspace:other' }
+        ]
+      }));
+      return;
+    }
+
+    res.writeHead(404, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ message: 'not found' }));
+  });
+  const apiBase = await listen(fakeApi);
+  const server = createGrayMatterMcpServer({ apiBase: `${apiBase}/v1` });
+  const baseUrl = await listen(server);
+
+  try {
+    const body = await postRpc(baseUrl, {
+      jsonrpc: '2.0',
+      id: 'quota',
+      method: 'tools/call',
+      params: {
+        name: 'memory_query',
+        arguments: {
+          query: 'Stainless sprint CRM warm leads founder outreach',
+          type: 'context',
+          sourceChannel: 'codex:workspace:crm',
+          limit: 5
+        }
+      }
+    });
+
+    const out = JSON.parse(body.result.content[0].text);
+    assert.equal(out.degraded, true);
+    assert.equal(out.reason, 'embedding_quota_exhausted');
+    assert.equal(out.retrievalMode, 'lexical_fallback');
+    assert.equal(out.count, 1);
+    assert.equal(out.results[0].id, 'mem-1');
+    assert.equal(requests[0].path, '/v1/MemoryEntry/query');
+    assert.equal(requests[1].path, '/v1/MemoryEntry');
+  } finally {
+    await closeServers(server, fakeApi);
+  }
+});
+
 test('memory_query returns auth recovery for 401', async () => {
   const fakeApi = createFakeApi(401, { message: 'token expired' });
   const apiBase = await listen(fakeApi);

--- a/plugins/graymatter/mcp-server/index.js
+++ b/plugins/graymatter/mcp-server/index.js
@@ -727,7 +727,7 @@ async function callTool(params, context) {
       return execute('memory_read', () => apiRequest(context, 'GET', `MemoryEntry/${encodeURIComponent(args.id)}`));
     case 'memory_query':
       requireString(args.query, 'query');
-      return execute('memory_query', () => apiRequest(context, 'POST', 'MemoryEntry/query', buildMemoryQueryPayload(args)));
+      return execute('memory_query', () => queryMemoryWithFallback(context, args));
     case 'memory_put_batch':
       return execute('memory_put_batch', async () => {
         if (!Array.isArray(args.items)) {
@@ -1385,6 +1385,106 @@ function buildRecoveryResult(error, operation, context) {
       }
     }
   };
+}
+
+async function queryMemoryWithFallback(context, args) {
+  const payload = buildMemoryQueryPayload(args);
+  try {
+    return await apiRequest(context, 'POST', 'MemoryEntry/query', payload);
+  } catch (error) {
+    if (!isEmbeddingQuotaFailure(error)) {
+      throw error;
+    }
+
+    const entries = await apiRequest(context, 'GET', 'MemoryEntry');
+    const results = lexicalMemoryFallback(entries, {
+      query: args.query,
+      limit: args.limit,
+      type: args.type,
+      source: payload.source
+    });
+
+    return {
+      degraded: true,
+      reason: 'embedding_quota_exhausted',
+      retrievalMode: 'lexical_fallback',
+      query: args.query,
+      count: results.length,
+      warning: 'Semantic memory search is unavailable because the embedding provider quota is exhausted. Results are lexical fallback matches from MemoryEntry list.',
+      action: 'Top up or switch the embedding provider, then retry semantic memory_query.',
+      results
+    };
+  }
+}
+
+function isEmbeddingQuotaFailure(error) {
+  if (!error || error.name !== 'ApiRequestError') {
+    return false;
+  }
+
+  const text = JSON.stringify(error.payload || error.message || '').toLowerCase();
+  return /insufficient_quota|quota exhausted|embedding provider quota|embeddings? failed|openai embeddings failed/.test(text);
+}
+
+function lexicalMemoryFallback(payload, options) {
+  const entries = normalizeMemoryEntries(payload);
+  const query = String(options.query || '').toLowerCase();
+  const terms = Array.from(new Set(query.split(/[^a-z0-9_-]+/u).filter((term) => term.length > 2)));
+  const limit = clampInteger(options.limit, 10, 1, 100);
+  const type = options.type || '';
+  const source = options.source || '';
+
+  return entries
+    .map((entry) => ({ entry, score: lexicalMemoryScore(entry, query, terms) }))
+    .filter(({ entry, score }) => {
+      if (type && entry.type !== type) {
+        return false;
+      }
+      if (source && entry.source !== source && entry.sourceChannel !== source) {
+        return false;
+      }
+      return score > 0;
+    })
+    .sort((left, right) => right.score - left.score)
+    .slice(0, limit)
+    .map(({ entry }) => entry);
+}
+
+function normalizeMemoryEntries(payload) {
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+  if (!payload || typeof payload !== 'object') {
+    return [];
+  }
+  for (const key of ['content', 'items', 'data', 'results', 'records']) {
+    if (Array.isArray(payload[key])) {
+      return payload[key];
+    }
+  }
+  return [];
+}
+
+function lexicalMemoryScore(entry, query, terms) {
+  const haystack = [
+    entry && entry.text,
+    entry && entry.title,
+    entry && entry.summary,
+    entry && entry.description,
+    entry && entry.content,
+    entry && entry.type,
+    Array.isArray(entry && entry.tags)
+      ? entry.tags.map((tag) => typeof tag === 'object' ? (tag.name || tag.id || '') : String(tag)).join(' ')
+      : ''
+  ].filter(Boolean).join(' ').toLowerCase();
+
+  if (!haystack) {
+    return 0;
+  }
+  if (terms.length === 0) {
+    return query && haystack.includes(query) ? 1 : 0;
+  }
+  return terms.reduce((score, term) => score + (haystack.includes(term) ? 1 : 0), 0);
 }
 
 function activationContextUrl(baseUrl, intent, operation, context = {}) {

--- a/plugins/graymatter/mcp-server/test/recovery.test.js
+++ b/plugins/graymatter/mcp-server/test/recovery.test.js
@@ -161,6 +161,71 @@ test('memory_query distinguishes missing starter credits from paid credit deplet
   }
 });
 
+test('memory_query falls back to lexical MemoryEntry list when embeddings quota is exhausted', async () => {
+  const requests = [];
+  const fakeApi = http.createServer(async (req, res) => {
+    const body = await readBody(req);
+    requests.push({ method: req.method, path: new URL(req.url, 'http://fake.local').pathname, body });
+
+    if (req.method === 'POST' && req.url === '/v1/MemoryEntry/query') {
+      res.writeHead(500, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({
+        disabled: true,
+        unavailable: true,
+        error: 'openai embeddings failed: 429 insufficient_quota',
+        warning: 'Memory search is unavailable because the embedding provider quota is exhausted.'
+      }));
+      return;
+    }
+
+    if (req.method === 'GET' && req.url === '/v1/MemoryEntry') {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({
+        content: [
+          { id: 'mem-1', type: 'context', text: 'Stainless sprint CRM warm leads need founder-led follow-up', sourceChannel: 'codex:workspace:crm' },
+          { id: 'mem-2', type: 'todo', text: 'Unrelated billing cleanup', sourceChannel: 'codex:workspace:crm' },
+          { id: 'mem-3', type: 'context', text: 'Stainless pricing objection notes', sourceChannel: 'codex:workspace:other' }
+        ]
+      }));
+      return;
+    }
+
+    res.writeHead(404, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ message: 'not found' }));
+  });
+  const apiBase = await listen(fakeApi);
+  const server = createGrayMatterMcpServer({ apiBase: `${apiBase}/v1` });
+  const baseUrl = await listen(server);
+
+  try {
+    const body = await postRpc(baseUrl, {
+      jsonrpc: '2.0',
+      id: 'quota',
+      method: 'tools/call',
+      params: {
+        name: 'memory_query',
+        arguments: {
+          query: 'Stainless sprint CRM warm leads founder outreach',
+          type: 'context',
+          sourceChannel: 'codex:workspace:crm',
+          limit: 5
+        }
+      }
+    });
+
+    const out = JSON.parse(body.result.content[0].text);
+    assert.equal(out.degraded, true);
+    assert.equal(out.reason, 'embedding_quota_exhausted');
+    assert.equal(out.retrievalMode, 'lexical_fallback');
+    assert.equal(out.count, 1);
+    assert.equal(out.results[0].id, 'mem-1');
+    assert.equal(requests[0].path, '/v1/MemoryEntry/query');
+    assert.equal(requests[1].path, '/v1/MemoryEntry');
+  } finally {
+    await closeServers(server, fakeApi);
+  }
+});
+
 test('memory_query returns auth recovery for 401', async () => {
   const fakeApi = createFakeApi(401, { message: 'token expired' });
   const apiBase = await listen(fakeApi);

--- a/scripts/gm-query
+++ b/scripts/gm-query
@@ -286,7 +286,7 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GRAYMATTER_API_COMMAND="${GRAYMATTER_API_COMMAND:-${SCRIPT_DIR}/graymatter_api.sh}"
 
-is_query_timeout_response() {
+is_query_degraded_response() {
   local file="$1"
 
   if [[ ! -s "$file" ]]; then
@@ -299,15 +299,19 @@ is_query_timeout_response() {
         .error?,
         .message?,
         .classification?,
+        .warning?,
+        .action?,
         .details?.error?,
-        .details?.message?
+        .details?.message?,
+        .details?.warning?,
+        .details?.action?
       ]
       | map(select(type == "string") | ascii_downcase)
-      | any(test("transaction timeout|timeout expired|timed out"))
+      | any(test("transaction timeout|timeout expired|timed out|insufficient_quota|quota exhausted|embeddings? failed|embedding provider quota"))
     ' "$file" >/dev/null 2>&1 && return 0
   fi
 
-  grep -Eiq 'transaction timeout|timeout expired|timed out' "$file"
+  grep -Eiq 'transaction timeout|timeout expired|timed out|insufficient_quota|quota exhausted|embeddings? failed|embedding provider quota' "$file"
 }
 
 fallback_memoryentry_filter() {
@@ -341,19 +345,33 @@ fallback_memoryentry_filter() {
           .description?,
           .content?,
           .type?,
-          .source?,
-          .sourceChannel?,
           tag_text
         ]
         | map(select(. != null) | tostring)
         | join(" ")
         | ascii_downcase;
+      def query_terms:
+        $q
+        | gsub("[^a-z0-9_-]+"; " ")
+        | split(" ")
+        | map(select(length > 2))
+        | unique;
+      def lexical_score($text):
+        query_terms as $terms
+        | if ($terms | length) == 0 then
+            (if ($text | contains($q)) then 1 else 0 end)
+          else
+            ($terms | map(. as $term | select($text | contains($term))) | length)
+          end;
       entries
+      | map(. as $entry | (searchable_text) as $text | $entry + {"_gmLexicalScore": lexical_score($text)})
       | map(select(
           ($type == "" or (.type? == $type))
           and ($source == "" or (.source? == $source) or (.sourceChannel? == $source))
-          and (searchable_text | contains($q))
+          and ((searchable_text | contains($q)) or (._gmLexicalScore > 0))
         ))
+      | sort_by(._gmLexicalScore) | reverse
+      | map(del(._gmLexicalScore))
       | .[:$limit]
     ' "$list_body"
 }
@@ -448,8 +466,8 @@ if [[ -s "$QUERY_RESPONSE" ]]; then
   echo >&2
 fi
 
-if [[ "${GRAYMATTER_QUERY_TIMEOUT_FALLBACK:-true}" == "true" ]] && is_query_timeout_response "$QUERY_RESPONSE"; then
-  echo "gm-query: MemoryEntry/query timed out; falling back to MemoryEntry list filtering" >&2
+if [[ "${GRAYMATTER_QUERY_TIMEOUT_FALLBACK:-true}" == "true" ]] && is_query_degraded_response "$QUERY_RESPONSE"; then
+  echo "gm-query: MemoryEntry/query degraded; falling back to MemoryEntry list filtering" >&2
   FALLBACK_RESPONSE="$(mktemp "${TMPDIR:-/tmp}/gm-query-fallback-response.XXXXXX")"
   trap 'rm -f "$QUERY_RESPONSE" "$FALLBACK_RESPONSE"' EXIT
   run_memoryentry_timeout_fallback >"$FALLBACK_RESPONSE"

--- a/tests/gm_query_test.sh
+++ b/tests/gm_query_test.sh
@@ -61,6 +61,64 @@ SH
   grep -q "falling back to MemoryEntry list filtering" "$err"
 }
 
+run_quota_fallback_filters_memory_entries_by_tokens() {
+  local fake_api="$TMP_DIR/fake-graymatter-api-quota"
+  local out="$TMP_DIR/query-quota.out"
+  local err="$TMP_DIR/query-quota.err"
+
+  cat >"$fake_api" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+METHOD="${1:-}"
+PATH_PART="${2:-}"
+
+if [[ "$METHOD" == "POST" && "$PATH_PART" == "/MemoryEntry/query" ]]; then
+  cat <<'JSON'
+{
+  "disabled": true,
+  "unavailable": true,
+  "error": "openai embeddings failed: 429 insufficient_quota",
+  "warning": "Memory search is unavailable because the embedding provider quota is exhausted.",
+  "action": "Top up or switch embedding provider, then retry memory_search."
+}
+JSON
+  exit 22
+fi
+
+if [[ "$METHOD" == "GET" && "$PATH_PART" == "/MemoryEntry" ]]; then
+  cat <<'JSON'
+[
+  {
+    "id": "crm-routing",
+    "type": "context",
+    "text": "Stainless sprint CRM warm leads need Jamarr response routing and do-not-contact risk notes.",
+    "sourceChannel": "codex:automation:growth-swarm-crm-steward-daily"
+  },
+  {
+    "id": "generic-memory",
+    "type": "context",
+    "text": "Unrelated operational status.",
+    "sourceChannel": "codex:automation:growth-swarm-crm-steward-daily"
+  }
+]
+JSON
+  exit 0
+fi
+
+echo "unexpected fake API call: $*" >&2
+exit 64
+SH
+  chmod +x "$fake_api"
+
+  GRAYMATTER_API_COMMAND="$fake_api" \
+    "$ROOT_DIR/scripts/gm-query" "Stainless sprint CRM warm leads founder-led outreach Jamarr response routing follow-up tasks opportunity stages do-not-contact risk notes" 10 context codex:automation:growth-swarm-crm-steward-daily \
+    >"$out" 2>"$err"
+
+  jq -e 'length == 1 and .[0].id == "crm-routing"' "$out" >/dev/null
+  grep -q "MemoryEntry/query degraded; falling back to MemoryEntry list filtering" "$err"
+}
+
 run_success_brief_formats_human_output() {
   local fake_api="$TMP_DIR/fake-graymatter-api-brief"
   local out="$TMP_DIR/query-brief.out"
@@ -333,6 +391,7 @@ SH
 }
 
 run_timeout_fallback_filters_memory_entries
+run_quota_fallback_filters_memory_entries_by_tokens
 run_success_brief_formats_human_output
 run_non_timeout_errors_do_not_fallback
 run_timeout_fallback_can_be_disabled


### PR DESCRIPTION
## Summary
- catches embedding-provider quota failures in GrayMatter MCP memory_query
- falls back to lexical filtering over MemoryEntry list results with degraded retrieval metadata
- keeps root and packaged plugin MCP copies aligned

## Tests
- npm test (mcp-server)
- npm test (plugins/graymatter/mcp-server)
- bash tests/gm_query_test.sh

Closes ValkyrLabs/ValkyrAI#3917
