### PR TITLE
fix(graymatter): dedupe fallback queue writes

### DIFF
--- a/plugins/graymatter/scripts/gm-fallback-append
+++ b/plugins/graymatter/scripts/gm-fallback-append
@@ -43,7 +43,23 @@ if [[ -f "$SPOOL" ]]; then
       | .timestamp = $now
       | .source = (.source // "chat")
       | .status = "pending_replay"
-      | .items += [{type:$type, text:$text, owner:$owner, reason:$reason}]
+      | .items =
+        ((.items // []) as $items
+        | if any($items[]?; .type == $type and .text == $text and .owner == $owner) then
+            $items
+            | map(
+                if .type == $type and .text == $text and .owner == $owner then
+                  .reason = $reason
+                  | .lastSeenAt = $now
+                  | .firstSeenAt = (.firstSeenAt // .timestamp // $now)
+                  | .duplicateCount = ((.duplicateCount // 0) + 1)
+                else
+                  .
+                end
+              )
+          else
+            $items + [{type:$type, text:$text, owner:$owner, reason:$reason, firstSeenAt:$now, lastSeenAt:$now, duplicateCount:0}]
+          end)
     ' >"$TMP"
 else
   jq -n \
@@ -52,7 +68,7 @@ else
     --arg text "$TEXT" \
     --arg owner "$OWNER" \
     --arg reason "$REASON" \
-    '{timestamp:$now, source:"chat", status:"pending_replay", items:[{type:$type, text:$text, owner:$owner, reason:$reason}]}' >"$TMP"
+    '{timestamp:$now, source:"chat", status:"pending_replay", items:[{type:$type, text:$text, owner:$owner, reason:$reason, firstSeenAt:$now, lastSeenAt:$now, duplicateCount:0}]}' >"$TMP"
 fi
 
 mv "$TMP" "$SPOOL"

--- a/scripts/gm-fallback-append
+++ b/scripts/gm-fallback-append
@@ -43,7 +43,23 @@ if [[ -f "$SPOOL" ]]; then
       | .timestamp = $now
       | .source = (.source // "chat")
       | .status = "pending_replay"
-      | .items += [{type:$type, text:$text, owner:$owner, reason:$reason}]
+      | .items =
+        ((.items // []) as $items
+        | if any($items[]?; .type == $type and .text == $text and .owner == $owner) then
+            $items
+            | map(
+                if .type == $type and .text == $text and .owner == $owner then
+                  .reason = $reason
+                  | .lastSeenAt = $now
+                  | .firstSeenAt = (.firstSeenAt // .timestamp // $now)
+                  | .duplicateCount = ((.duplicateCount // 0) + 1)
+                else
+                  .
+                end
+              )
+          else
+            $items + [{type:$type, text:$text, owner:$owner, reason:$reason, firstSeenAt:$now, lastSeenAt:$now, duplicateCount:0}]
+          end)
     ' >"$TMP"
 else
   jq -n \
@@ -52,7 +68,7 @@ else
     --arg text "$TEXT" \
     --arg owner "$OWNER" \
     --arg reason "$REASON" \
-    '{timestamp:$now, source:"chat", status:"pending_replay", items:[{type:$type, text:$text, owner:$owner, reason:$reason}]}' >"$TMP"
+    '{timestamp:$now, source:"chat", status:"pending_replay", items:[{type:$type, text:$text, owner:$owner, reason:$reason, firstSeenAt:$now, lastSeenAt:$now, duplicateCount:0}]}' >"$TMP"
 fi
 
 mv "$TMP" "$SPOOL"

--- a/tests/gm_fallback_append_test.sh
+++ b/tests/gm_fallback_append_test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+SPOOL="$TMP_DIR/graymatter-fallback.json"
+
+GRAYMATTER_FALLBACK_SPOOL="$SPOOL" "$ROOT_DIR/scripts/gm-fallback-append" artifact "same payload" positioning-brain "deadlock"
+GRAYMATTER_FALLBACK_SPOOL="$SPOOL" "$ROOT_DIR/scripts/gm-fallback-append" artifact "same payload" positioning-brain "table definition changed"
+GRAYMATTER_FALLBACK_SPOOL="$SPOOL" "$ROOT_DIR/scripts/gm-fallback-append" artifact "other payload" positioning-brain "deadlock"
+
+jq -e '.status == "pending_replay"' "$SPOOL" >/dev/null
+jq -e '.items | length == 2' "$SPOOL" >/dev/null
+jq -e '
+  .items[]
+  | select(.text == "same payload")
+  | .reason == "table definition changed"
+    and .duplicateCount == 1
+    and (.firstSeenAt | type == "string")
+    and (.lastSeenAt | type == "string")
+' "$SPOOL" >/dev/null
+jq -e '.items[] | select(.text == "other payload") | .duplicateCount == 0' "$SPOOL" >/dev/null
+
+PLUGIN_SPOOL="$TMP_DIR/plugin-graymatter-fallback.json"
+GRAYMATTER_FALLBACK_SPOOL="$PLUGIN_SPOOL" "$ROOT_DIR/plugins/graymatter/scripts/gm-fallback-append" context "same payload" openclaw "first failure"
+GRAYMATTER_FALLBACK_SPOOL="$PLUGIN_SPOOL" "$ROOT_DIR/plugins/graymatter/scripts/gm-fallback-append" context "same payload" openclaw "second failure"
+
+jq -e '.items | length == 1' "$PLUGIN_SPOOL" >/dev/null
+jq -e '.items[0].duplicateCount == 1 and .items[0].reason == "second failure"' "$PLUGIN_SPOOL" >/dev/null
+
+echo "gm_fallback_append_test: PASS"


### PR DESCRIPTION
## Summary
- make gm-fallback-append coalesce repeated failed writes by type/text/owner instead of appending duplicate replay entries
- track firstSeenAt, lastSeenAt, and duplicateCount for retry diagnostics
- sync the packaged GrayMatter plugin script copy

## Tests
- tests/gm_fallback_append_test.sh
- tests/gm_write_test.sh
- tests/release_surfaces_test.sh

Refs ValkyrLabs/ValkyrAI#3468